### PR TITLE
0.10.x

### DIFF
--- a/Assets/ColyseusClient.cs
+++ b/Assets/ColyseusClient.cs
@@ -61,7 +61,7 @@ public class ColyseusClient : MonoBehaviour {
 			/* Update Demo UI */
 			m_IdText.text = "id: " + client.id;
 		};
-		client.OnError += (sender, e) => Debug.LogError(e.message);
+		client.OnError += (sender, e) => Debug.LogError(e.Message);
 		client.OnClose += (sender, e) => Debug.Log("CONNECTION CLOSED");
 		StartCoroutine(client.Connect());
 	}
@@ -79,7 +79,7 @@ public class ColyseusClient : MonoBehaviour {
 		};
 		room.OnError += (sender, e) =>
 		{
-			Debug.LogError(e.message);
+			Debug.LogError(e.Message);
 		};
 		room.OnJoin += (sender, e) => {
 			Debug.Log("Joined room successfully.");
@@ -113,17 +113,20 @@ public class ColyseusClient : MonoBehaviour {
 			Debug.Log("Ready to connect to room!");
 			StartCoroutine(room.Connect());
 		};
-		room.OnError += (sender, e) => Debug.LogError(e.message);
+		room.OnError += (sender, e) => Debug.LogError(e.Message);
 		room.OnJoin += (sender, e) => {
 			Debug.Log("Joined room successfully.");
 			m_SessionIdText.text = "sessionId: " + room.sessionId;
+
 		};
 		room.OnStateChange += OnStateChangeHandler;
 
+		// only register listeners after OnJoin.
 		room.Listen("players/:id", this.OnPlayerChange);
 		room.Listen("players/:id/:axis", this.OnPlayerMove);
 		room.Listen("messages/:number", this.OnMessageAdded);
 		room.Listen(this.OnChangeFallback);
+
 
 		room.OnMessage += OnMessage;
 	}
@@ -155,16 +158,14 @@ public class ColyseusClient : MonoBehaviour {
 
 	void OnMessage (object sender, DataEventArgs e)
 	{
-		var message = (IndexedDictionary<string, object>) e.message;
+//		var message = (IndexedDictionary<string, object>) e.Data;
 //		Debug.Log(data);
 	}
 
 	void OnStateChangeHandler (object sender, StateChangeEventArgs e)
 	{
 		// Setup room first state
-		if (e.isFirstState) {
-			IndexedDictionary<string, object> players = (IndexedDictionary<string, object>) e.state ["players"];
-		}
+		Debug.Log("State has been updated!");
 	}
 
 	void OnPlayerChange (DataChange change)

--- a/Assets/ColyseusClient.cs
+++ b/Assets/ColyseusClient.cs
@@ -62,7 +62,7 @@ public class ColyseusClient : MonoBehaviour {
 			m_IdText.text = "id: " + client.id;
 		};
 		client.OnError += (sender, e) => Debug.LogError(e.message);
-		client.OnClose += (object sender, EventArgs e) => Debug.Log("CONNECTION CLOSED");
+		client.OnClose += (sender, e) => Debug.Log("CONNECTION CLOSED");
 		StartCoroutine(client.Connect());
 	}
 
@@ -77,7 +77,10 @@ public class ColyseusClient : MonoBehaviour {
 			Debug.Log("Ready to connect to room!");
 			StartCoroutine(room.Connect());
 		};
-		room.OnError += (sender, e) => Debug.LogError(e.message);
+		room.OnError += (sender, e) =>
+		{
+			Debug.LogError(e.message);
+		};
 		room.OnJoin += (sender, e) => {
 			Debug.Log("Joined room successfully.");
 			m_SessionIdText.text = "sessionId: " + room.sessionId;
@@ -150,13 +153,13 @@ public class ColyseusClient : MonoBehaviour {
 		}
 	}
 
-	void OnMessage (object sender, MessageEventArgs e)
+	void OnMessage (object sender, DataEventArgs e)
 	{
 		var message = (IndexedDictionary<string, object>) e.message;
 //		Debug.Log(data);
 	}
 
-	void OnStateChangeHandler (object sender, RoomUpdateEventArgs e)
+	void OnStateChangeHandler (object sender, StateChangeEventArgs e)
 	{
 		// Setup room first state
 		if (e.isFirstState) {

--- a/Assets/ColyseusClient.cs
+++ b/Assets/ColyseusClient.cs
@@ -85,16 +85,16 @@ public class ColyseusClient : MonoBehaviour {
 			Debug.Log("Joined room successfully.");
 			m_SessionIdText.text = "sessionId: " + room.sessionId;
 
+			room.Listen("players/:id", OnPlayerChange, true);
+			room.Listen("players/:id/:axis", OnPlayerMove);
+			room.Listen("messages/:number", OnMessageAdded);
+			room.Listen(OnChangeFallback);
+
 			PlayerPrefs.SetString("sessionId", room.sessionId);
 			PlayerPrefs.Save();
 		};
+
 		room.OnStateChange += OnStateChangeHandler;
-
-		room.Listen("players/:id", this.OnPlayerChange);
-		room.Listen("players/:id/:axis", this.OnPlayerMove);
-		room.Listen("messages/:number", this.OnMessageAdded);
-		room.Listen(this.OnChangeFallback);
-
 		room.OnMessage += OnMessage;
 	}
 
@@ -118,16 +118,14 @@ public class ColyseusClient : MonoBehaviour {
 			Debug.Log("Joined room successfully.");
 			m_SessionIdText.text = "sessionId: " + room.sessionId;
 
+			// only register listeners after OnJoin.
+			room.Listen("players/:id", OnPlayerChange, true);
+			room.Listen("players/:id/:axis", OnPlayerMove);
+			room.Listen("messages/:number", OnMessageAdded);
+			room.Listen(OnChangeFallback);
 		};
+
 		room.OnStateChange += OnStateChangeHandler;
-
-		// only register listeners after OnJoin.
-		room.Listen("players/:id", this.OnPlayerChange);
-		room.Listen("players/:id/:axis", this.OnPlayerMove);
-		room.Listen("messages/:number", this.OnMessageAdded);
-		room.Listen(this.OnChangeFallback);
-
-
 		room.OnMessage += OnMessage;
 	}
 
@@ -136,12 +134,12 @@ public class ColyseusClient : MonoBehaviour {
 		room.Leave(false);
 
 		// Destroy player entities
-		foreach (KeyValuePair<string, GameObject> entry in this.players)
+		foreach (KeyValuePair<string, GameObject> entry in players)
 		{
 			Destroy(entry.Value);
 		}
 
-		this.players.Clear();
+		players.Clear();
 	}
 
 	void SendMessage()
@@ -156,10 +154,10 @@ public class ColyseusClient : MonoBehaviour {
 		}
 	}
 
-	void OnMessage (object sender, DataEventArgs e)
+	void OnMessage (object sender, MessageEventArgs e)
 	{
-//		var message = (IndexedDictionary<string, object>) e.Data;
-//		Debug.Log(data);
+		var message = (IndexedDictionary<string, object>) e.Message;
+		Debug.Log(message);
 	}
 
 	void OnStateChangeHandler (object sender, StateChangeEventArgs e)

--- a/Assets/ColyseusClient.cs
+++ b/Assets/ColyseusClient.cs
@@ -83,14 +83,14 @@ public class ColyseusClient : MonoBehaviour {
 		};
 		room.OnJoin += (sender, e) => {
 			Debug.Log("Joined room successfully.");
-			m_SessionIdText.text = "sessionId: " + room.sessionId;
+			m_SessionIdText.text = "sessionId: " + room.SessionId;
 
 			room.Listen("players/:id", OnPlayerChange, true);
 			room.Listen("players/:id/:axis", OnPlayerMove);
 			room.Listen("messages/:number", OnMessageAdded);
 			room.Listen(OnChangeFallback);
 
-			PlayerPrefs.SetString("sessionId", room.sessionId);
+			PlayerPrefs.SetString("sessionId", room.SessionId);
 			PlayerPrefs.Save();
 		};
 
@@ -116,7 +116,7 @@ public class ColyseusClient : MonoBehaviour {
 		room.OnError += (sender, e) => Debug.LogError(e.Message);
 		room.OnJoin += (sender, e) => {
 			Debug.Log("Joined room successfully.");
-			m_SessionIdText.text = "sessionId: " + room.sessionId;
+			m_SessionIdText.text = "sessionId: " + room.SessionId;
 
 			// only register listeners after OnJoin.
 			room.Listen("players/:id", OnPlayerChange, true);

--- a/Assets/ColyseusClient.cs
+++ b/Assets/ColyseusClient.cs
@@ -59,7 +59,7 @@ public class ColyseusClient : MonoBehaviour {
 		client = new Client(endpoint);
 		client.OnOpen += (object sender, EventArgs e) => {
 			/* Update Demo UI */
-			m_IdText.text = "id: " + client.id;
+			m_IdText.text = "id: " + client.Id;
 		};
 		client.OnError += (sender, e) => Debug.LogError(e.Message);
 		client.OnClose += (sender, e) => Debug.Log("CONNECTION CLOSED");

--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -18,21 +18,10 @@ namespace Colyseus
 		/// <summary>
 		/// Unique <see cref="Client"/> identifier.
 		/// </summary>
-		public string id;
-		protected UriBuilder endpoint;
-
-		protected Connection connection;
-
-		protected Dictionary<string, Room> rooms = new Dictionary<string, Room> ();
-		protected Dictionary<int, IRoom> connectingRooms = new Dictionary<int, IRoom> ();
-
-		protected int _requestId;
-		protected Dictionary<int, Action<RoomAvailable[]>> roomsAvailableRequests = new Dictionary<int, Action<RoomAvailable[]>>();
-
-		protected byte previousCode = 0;
+		public string Id;
 
 		/// <summary>
-		/// Occurs when the <see cref="Client"/> connection has been established, and Client <see cref="id"/> is available.
+		/// Occurs when the <see cref="Client"/> connection has been established, and Client <see cref="Id"/> is available.
 		/// </summary>
 		public event EventHandler OnOpen;
 
@@ -46,10 +35,16 @@ namespace Colyseus
 		/// </summary>
 		public event EventHandler<ErrorEventArgs> OnError;
 
-		/// <summary>
-		/// Occurs when the <see cref="Client"/> receives a message from server.
-		/// </summary>
-		public event EventHandler<MessageEventArgs> OnMessage;
+		protected UriBuilder endpoint;
+		protected Connection connection;
+
+		protected Dictionary<string, Room> rooms = new Dictionary<string, Room> ();
+		protected Dictionary<int, IRoom> connectingRooms = new Dictionary<int, IRoom> ();
+
+		protected int _requestId;
+		protected Dictionary<int, Action<RoomAvailable[]>> roomsAvailableRequests = new Dictionary<int, Action<RoomAvailable[]>>();
+
+		protected byte previousCode = 0;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Client"/> class with
@@ -60,7 +55,7 @@ namespace Colyseus
 		/// </param>
 		public Client (string _endpoint, string _id = null)
 		{
-			id = _id;
+			Id = _id;
 			endpoint = new UriBuilder(new Uri (_endpoint));
 			connection = CreateConnection();
 			connection.OnClose += (sender, e) =>
@@ -150,8 +145,8 @@ namespace Colyseus
 				options = new Dictionary<string, object> ();
 			}
 
-			if (id != null) {
-				options.Add ("colyseusid", id);
+			if (Id != null) {
+				options.Add ("colyseusid", Id);
 			}
 
 			var list = new List<string>();
@@ -178,7 +173,7 @@ namespace Colyseus
 
 				if (code == Protocol.USER_ID)
 				{
-					id = System.Text.Encoding.UTF8.GetString(bytes, 2, bytes[1]);
+					Id = System.Text.Encoding.UTF8.GetString(bytes, 2, bytes[1]);
 
 					if (OnOpen != null)
 						OnOpen.Invoke(this, EventArgs.Empty);
@@ -192,19 +187,19 @@ namespace Colyseus
 					if (connectingRooms.TryGetValue(requestId, out _room))
 					{
 						Room room = (Room)_room;
-						room.id = System.Text.Encoding.UTF8.GetString(bytes, 3, bytes[2]);
+						room.Id = System.Text.Encoding.UTF8.GetString(bytes, 3, bytes[2]);
 
-						endpoint.Path = "/" + room.id;
-						endpoint.Query = "colyseusid=" + this.id;
+						endpoint.Path = "/" + room.Id;
+						endpoint.Query = "colyseusid=" + this.Id;
 
-						room.SetConnection(CreateConnection(room.id, room.options));
+						room.SetConnection(CreateConnection(room.Id, room.Options));
 						room.OnLeave += OnLeaveRoom;
 
-						if (rooms.ContainsKey(room.id))
+						if (rooms.ContainsKey(room.Id))
 						{
-							rooms.Remove(room.id);
+							rooms.Remove(room.Id);
 						}
-						rooms.Add(room.id, room);
+						rooms.Add(room.Id, room);
 						connectingRooms.Remove(requestId);
 
 					}
@@ -254,7 +249,7 @@ namespace Colyseus
 		protected void OnLeaveRoom (object sender, EventArgs args)
 		{
 			Room room = (Room) sender;
-			rooms.Remove (room.id);
+			rooms.Remove (room.Id);
 		}
 
 	}

--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -49,7 +49,7 @@ namespace Colyseus
 		/// <summary>
 		/// Occurs when the <see cref="Client"/> receives a message from server.
 		/// </summary>
-		public event EventHandler<DataEventArgs> OnMessage;
+		public event EventHandler<MessageEventArgs> OnMessage;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Client"/> class with

--- a/Assets/Plugins/Colyseus/Events.cs
+++ b/Assets/Plugins/Colyseus/Events.cs
@@ -44,16 +44,20 @@ namespace Colyseus
 	/// <summary>
 	/// Room Update Message
 	/// </summary>
-	public class StateChangeEventArgs<T> : EventArgs
+	//public class StateChangeEventArgs<T> : EventArgs
+	public class StateChangeEventArgs : EventArgs
 	{
 		/// <summary>
 		/// New state of the <see cref="Room" />
 		/// </summary>
-		public T State { get; private set; }
+		//public T State { get; private set; }
+
+		public IndexedDictionary<string, object> State { get; private set; }
+
 
 		/// <summary>
 		/// </summary>
-		public StateChangeEventArgs (T state)
+		public StateChangeEventArgs (IndexedDictionary<string, object> state)
 		{
 			this.State = state;
 		}

--- a/Assets/Plugins/Colyseus/Events.cs
+++ b/Assets/Plugins/Colyseus/Events.cs
@@ -54,12 +54,17 @@ namespace Colyseus
 
 		public IndexedDictionary<string, object> State { get; private set; }
 
+		/// <summary>	
+		/// Boolean representing if the event is setting the state of the <see cref="Room" /> for the first time.	
+		/// </summary>
+		public bool IsFirstState;
 
 		/// <summary>
 		/// </summary>
-		public StateChangeEventArgs (IndexedDictionary<string, object> state)
+		public StateChangeEventArgs (IndexedDictionary<string, object> state, bool isFirstState = false)
 		{
 			this.State = state;
+			this.IsFirstState = isFirstState;
 		}
 	}
 }

--- a/Assets/Plugins/Colyseus/Events.cs
+++ b/Assets/Plugins/Colyseus/Events.cs
@@ -26,18 +26,18 @@ namespace Colyseus
 	/// <summary>
 	/// Representation of a message received from the server.
 	/// </summary>
-	public class DataEventArgs : EventArgs
+	public class MessageEventArgs : EventArgs
 	{
 		/// <summary>
 		/// Message coming from the server.
 		/// </summary>
-		public object Data;
+		public object Message;
 
 		/// <summary>
 		/// </summary>
-		public DataEventArgs (object _data)
+		public MessageEventArgs (object _message)
 		{
-			Data = _data;
+			Message = _message;
 		}
 	}
 

--- a/Assets/Plugins/Colyseus/Events.cs
+++ b/Assets/Plugins/Colyseus/Events.cs
@@ -13,55 +13,49 @@ namespace Colyseus
 		/// <summary>
 		/// The error message
 		/// </summary>
-		public string message = null;
+		public string Message = null;
 
 		/// <summary>
 		/// </summary>
 		public ErrorEventArgs (string message)
 		{
-			this.message = message;
+			this.Message = message;
 		}
 	}
 
 	/// <summary>
 	/// Representation of a message received from the server.
 	/// </summary>
-	public class MessageEventArgs : EventArgs
+	public class DataEventArgs : EventArgs
 	{
 		/// <summary>
 		/// Message coming from the server.
 		/// </summary>
-		public object message = null;
+		public object Data;
 
 		/// <summary>
 		/// </summary>
-		public MessageEventArgs (object message)
+		public DataEventArgs (object _data)
 		{
-			this.message = message;
+			Data = _data;
 		}
 	}
 
 	/// <summary>
 	/// Room Update Message
 	/// </summary>
-	public class RoomUpdateEventArgs : EventArgs
+	public class StateChangeEventArgs<T> : EventArgs
 	{
 		/// <summary>
 		/// New state of the <see cref="Room" />
 		/// </summary>
-		public IndexedDictionary<string, object> state;
-
-		/// <summary>
-		/// Boolean representing if the event is setting the state of the <see cref="Room" /> for the first time.
-		/// </summary>
-		public bool isFirstState;
+		public T State { get; private set; }
 
 		/// <summary>
 		/// </summary>
-		public RoomUpdateEventArgs (IndexedDictionary<string, object> state, bool isFirstState = false)
+		public StateChangeEventArgs (T state)
 		{
-			this.state = state;
-			this.isFirstState = isFirstState;
+			this.State = state;
 		}
 	}
 }

--- a/Assets/Plugins/Colyseus/Protocol.cs
+++ b/Assets/Plugins/Colyseus/Protocol.cs
@@ -11,8 +11,11 @@ namespace Colyseus
 		public static int USER_ID = 1;
 
 		//
-		// Room-related (10~20)
+		// Room-related (9~19)
 		//
+
+		/// <summary>When JOIN is requested.</summary>
+		public static int JOIN_REQUEST = 9;
 
 		/// <summary>When JOIN request is accepted.</summary>
 		public static int JOIN_ROOM = 10;

--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -127,7 +127,7 @@ namespace Colyseus
 			serializer.SetState(encodedState);
 
 			if (OnStateChange != null) {
-				OnStateChange.Invoke (this, new StateChangeEventArgs(serializer.GetState()));
+				OnStateChange.Invoke (this, new StateChangeEventArgs(serializer.GetState(), true));
 			}
 		}
 

--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -27,15 +27,15 @@ namespace Colyseus
 	// public class Room<T> : IRoom
 	public class Room : IRoom
 	{
-		public string id;
-		public string name;
-		public string sessionId;
+		public string Id;
+		public string Name;
+		public string SessionId;
 
-		public Dictionary<string, object> options;
+		public Dictionary<string, object> Options;
 
-		public Connection connection;
+		public Connection Connection;
 
-		public string serializerId;
+		public string SerializerId;
 		// protected Serializer<T> serializer;
 		protected Serializer serializer;
 
@@ -82,8 +82,8 @@ namespace Colyseus
 		/// <param name="name">The name of the room</param>
 		public Room (string name, Dictionary<string, object> options = null)
 		{
-			this.name = name;
-			this.options = options;
+			this.Name = name;
+			this.Options = options;
 
 			// TODO: remove default serializer. it should arrive only after JOIN_ROOM.
 			this.serializer = (Colyseus.Serializer) new FossilDeltaSerializer();
@@ -91,29 +91,29 @@ namespace Colyseus
 
 		public void Recv ()
 		{
-			byte[] data = connection.Recv();
+			byte[] data = Connection.Recv();
 			if (data != null)
 			{
 				ParseMessage(data);
 			}
 		}
 
-		public IEnumerator Connect ()
+		public IEnumerator Connect()
 		{
-			return connection.Connect ();
+			return Connection.Connect();
 		}
 
 		public void SetConnection (Connection connection)
 		{
-			this.connection = connection;
+			this.Connection = connection;
 
-			this.connection.OnClose += (object sender, EventArgs e) => {
+			this.Connection.OnClose += (object sender, EventArgs e) => {
 				if (OnLeave != null) {
 					OnLeave.Invoke (this, e);
 				}
 			};
 
-			this.connection.OnError += (object sender, ErrorEventArgs e) => {
+			this.Connection.OnError += (object sender, ErrorEventArgs e) => {
 				if (OnError != null) {
 					OnError.Invoke(this, e);
 				}
@@ -131,19 +131,24 @@ namespace Colyseus
 			}
 		}
 
+		public IndexedDictionary<string, object> State
+		{
+			get { return serializer.GetState(); }
+		}
+
 		/// <summary>
 		/// Leave the room.
 		/// </summary>
 		public void Leave (bool consented = true)
 		{
-			if (id != null) {
+			if (Id != null) {
 				if (consented)
 				{
-					connection.Send(new object[] { Protocol.LEAVE_ROOM }); 
+					Connection.Send(new object[] { Protocol.LEAVE_ROOM }); 
 				}
 				else
 				{
-					connection.Close();
+					Connection.Close();
 				}
 
 			} else if (OnLeave != null) {
@@ -157,12 +162,12 @@ namespace Colyseus
 		/// <param name="data">Data to be sent</param>
 		public void Send (object data)
 		{
-			connection.Send(new object[]{Protocol.ROOM_DATA, id, data});
+			Connection.Send(new object[]{Protocol.ROOM_DATA, Id, data});
 		}
 
 		public Listener<Action<PatchObject>> Listen(Action<PatchObject> callback)
 		{
-			if (string.IsNullOrEmpty(serializerId))
+			if (string.IsNullOrEmpty(SerializerId))
 			{
 				Debug.LogWarning("room.Listen() should be called after room.OnJoin has been called (DEPRECATION WARNING)");
 			}
@@ -171,7 +176,7 @@ namespace Colyseus
 
 		public Listener<Action<DataChange>> Listen(string segments, Action<DataChange> callback, bool immediate = false)
 		{
-			if (string.IsNullOrEmpty(serializerId))
+			if (string.IsNullOrEmpty(SerializerId))
 			{
 				Debug.LogWarning("room.Listen() should be called after room.OnJoin has been called (DEPRECATION WARNING)");
 			}
@@ -188,11 +193,11 @@ namespace Colyseus
 				{
 					var offset = 1;
 
-					sessionId = System.Text.Encoding.UTF8.GetString(bytes, offset+1, bytes[offset]);
-					offset += sessionId.Length + 1;
+					SessionId = System.Text.Encoding.UTF8.GetString(bytes, offset+1, bytes[offset]);
+					offset += SessionId.Length + 1;
 
-					serializerId = System.Text.Encoding.UTF8.GetString(bytes, offset+1, bytes[offset]);
-					offset += serializerId.Length + 1;
+					SerializerId = System.Text.Encoding.UTF8.GetString(bytes, offset+1, bytes[offset]);
+					offset += SerializerId.Length + 1;
 
 					// TODO: use serializer defined by the back-end.
 					// serializer = (Colyseus.Serializer) new FossilDeltaSerializer();

--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -64,7 +64,7 @@ namespace Colyseus
 		/// <summary>
 		/// Occurs when server sends a message to this <see cref="Room"/>
 		/// </summary>
-		public event EventHandler<DataEventArgs> OnMessage;
+		public event EventHandler<MessageEventArgs> OnMessage;
 
 		/// <summary>
 		/// Occurs after applying the patched state on this <see cref="Room"/>.
@@ -237,7 +237,7 @@ namespace Colyseus
 				else if (previousCode == Protocol.ROOM_DATA)
 				{
 					var message = MsgPack.Deserialize<object>(new MemoryStream(bytes));
-					OnMessage.Invoke(this, new DataEventArgs(message));
+					OnMessage.Invoke(this, new MessageEventArgs(message));
 
 				}
 				previousCode = 0;

--- a/Assets/Plugins/Colyseus/Serializer/FossilDeltaSerializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/FossilDeltaSerializer.cs
@@ -1,10 +1,38 @@
 using System;
+using System.IO;
+using GameDevWare.Serialization;
 
 namespace Colyseus
 {
-	public class FossilDeltaSerializer<T>
+	public class FossilDeltaSerializer<T> : Serializer<T>
 	{
-		public FossilDeltaSerializer()
+		protected StateContainer state = new StateContainer(new IndexedDictionary<string, object>());
+		protected byte[] previousState = null;
+
+		void SetState(byte[] encodedState)
+		{
+			Set(MsgPack.Deserialize<IndexedDictionary<string, object>> (new MemoryStream(encodedState)));
+			previousState = encodedState;
+		}
+
+		T GetState()
+		{
+			return state.state;
+		}
+
+		void Patch(byte[] data)
+		{
+			previousState = Fossil.Delta.Apply (previousState, delta);
+			var newState = MsgPack.Deserialize<IndexedDictionary<string, object>> (new MemoryStream(previousState));
+			Set(newState);
+		}
+
+	    void Teardown ()
+		{
+			state.RemoveAllListeners();
+		}
+
+    	void Handshake (byte[] bytes)
 		{
 		}
 	}

--- a/Assets/Plugins/Colyseus/Serializer/FossilDeltaSerializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/FossilDeltaSerializer.cs
@@ -1,39 +1,41 @@
-using System;
+using UnityEngine;
 using System.IO;
 using GameDevWare.Serialization;
 
 namespace Colyseus
 {
-	public class FossilDeltaSerializer<T> : Serializer<T>
+	/* public class FossilDeltaSerializer<T> : Serializer<T> */
+	public class FossilDeltaSerializer : Serializer
 	{
-		protected StateContainer state = new StateContainer(new IndexedDictionary<string, object>());
+		public StateContainer State = new StateContainer(new IndexedDictionary<string, object>());
 		protected byte[] previousState = null;
 
-		void SetState(byte[] encodedState)
-		{
-			Set(MsgPack.Deserialize<IndexedDictionary<string, object>> (new MemoryStream(encodedState)));
+		public void SetState(byte[] encodedState)
+        {
+			State.Set(MsgPack.Deserialize<IndexedDictionary<string, object>> (new MemoryStream(encodedState)));
 			previousState = encodedState;
 		}
 
-		T GetState()
+		public IndexedDictionary<string, object> GetState()
 		{
-			return state.state;
+			return State.state;
 		}
 
-		void Patch(byte[] data)
+		public void Patch(byte[] bytes)
 		{
-			previousState = Fossil.Delta.Apply (previousState, delta);
+			previousState = Fossil.Delta.Apply (previousState, bytes);
 			var newState = MsgPack.Deserialize<IndexedDictionary<string, object>> (new MemoryStream(previousState));
-			Set(newState);
+			State.Set(newState);
 		}
 
-	    void Teardown ()
+	    public void Teardown ()
 		{
-			state.RemoveAllListeners();
+			State.RemoveAllListeners();
 		}
 
-    	void Handshake (byte[] bytes)
+    	public void Handshake (byte[] bytes, int offset)
 		{
+			Debug.Log("Handshake FossilDeltaSerializer!");
 		}
 	}
 }

--- a/Assets/Plugins/Colyseus/Serializer/FossilDeltaSerializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/FossilDeltaSerializer.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Colyseus
+{
+	public class FossilDeltaSerializer<T>
+	{
+		public FossilDeltaSerializer()
+		{
+		}
+	}
+}

--- a/Assets/Plugins/Colyseus/Serializer/SchemaSerializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/SchemaSerializer.cs
@@ -4,7 +4,23 @@ namespace Colyseus
 {
 	public class SchemaSerializer<T>
 	{
-		public SchemaSerializer()
+		void SetState(byte[] data)
+		{
+		}
+
+		T GetState()
+		{
+		}
+
+		void Patch(byte[] data)
+		{
+		}
+
+	    void Teardown ()
+		{
+		}
+
+    	void Handshake (byte[] bytes)
 		{
 		}
 	}

--- a/Assets/Plugins/Colyseus/Serializer/SchemaSerializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/SchemaSerializer.cs
@@ -2,26 +2,29 @@ using System;
 
 namespace Colyseus
 {
+	/*
 	public class SchemaSerializer<T>
 	{
-		void SetState(byte[] data)
+		public void SetState(byte[] data)
 		{
 		}
 
-		T GetState()
+		public T GetState()
+		{
+			return new T;
+		}
+
+		public void Patch(byte[] data)
 		{
 		}
 
-		void Patch(byte[] data)
+	    public void Teardown ()
 		{
 		}
 
-	    void Teardown ()
-		{
-		}
-
-    	void Handshake (byte[] bytes)
+    	public void Handshake (byte[] bytes, int offset)
 		{
 		}
 	}
+	*/
 }

--- a/Assets/Plugins/Colyseus/Serializer/SchemaSerializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/SchemaSerializer.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Colyseus
+{
+	public class SchemaSerializer<T>
+	{
+		public SchemaSerializer()
+		{
+		}
+	}
+}

--- a/Assets/Plugins/Colyseus/Serializer/Serializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/Serializer.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Colyseus
+{
+	public class Serializer
+	{
+		public Serializer()
+		{
+		}
+	}
+}

--- a/Assets/Plugins/Colyseus/Serializer/Serializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/Serializer.cs
@@ -2,10 +2,13 @@ using System;
 
 namespace Colyseus
 {
-	public class Serializer
+	public interface Serializer<T>
 	{
-		public Serializer()
-		{
-		}
+		void SetState(byte[] data);
+		T GetState();
+		void Patch(byte[] data);
+
+	    void Teardown ();
+    	void Handshake (byte[] bytes);
 	}
 }

--- a/Assets/Plugins/Colyseus/Serializer/Serializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/Serializer.cs
@@ -1,14 +1,16 @@
 using System;
+using GameDevWare.Serialization;
 
 namespace Colyseus
 {
-	public interface Serializer<T>
+	public interface Serializer /* <T> */
 	{
 		void SetState(byte[] data);
-		T GetState();
+		// T GetState();
+		IndexedDictionary<string, object> GetState();
 		void Patch(byte[] data);
 
 	    void Teardown ();
-    	void Handshake (byte[] bytes);
+    	void Handshake (byte[] bytes, int offset);
 	}
 }

--- a/Assets/Plugins/Colyseus/StateListener/StateContainer.cs
+++ b/Assets/Plugins/Colyseus/StateListener/StateContainer.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Text.RegularExpressions;
-using System.Collections;
 using System.Collections.Generic;
 
 using GameDevWare.Serialization;
-using GameDevWare.Serialization.MessagePack;
 
 namespace Colyseus
 {

--- a/Assets/Tests/ClientComponent.cs
+++ b/Assets/Tests/ClientComponent.cs
@@ -9,11 +9,11 @@ public class ClientComponent : MonoBehaviour
 
 	// Use this for initialization
 	public IEnumerator Start () {
-		client = new Client("ws://localhost:8080");
+		client = new Client("ws://localhost:2567");
 
 		yield return StartCoroutine(client.Connect());
 
-		room  = client.Join("chat");
+		room = client.Join("chat");
 		room.OnReadyToConnect += (sender, e) => StartCoroutine ( room.Connect() );
 
 		while (true)

--- a/Assets/Tests/RoomTest.cs
+++ b/Assets/Tests/RoomTest.cs
@@ -28,7 +28,7 @@ public class RoomTest {
 			Assert.NotNull (component.room.sessionId);
 		};
 
-		component.room.OnStateChange += (object sender, RoomUpdateEventArgs e) => {
+		component.room.OnStateChange += (object sender, StateChangeEventArgs e) => {
 			Assert.NotNull (component.room.state ["players"]);
 			Assert.NotNull (component.room.state ["messages"]);
 		};

--- a/Assets/Tests/RoomTest.cs
+++ b/Assets/Tests/RoomTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
@@ -24,15 +24,13 @@ public class RoomTest {
 		yield return new WaitForSeconds(0.1f);
 
 		component.room.OnJoin += (object sender, System.EventArgs e) => {
-			Assert.NotNull (component.room.id);
-			Assert.NotNull (component.room.sessionId);
+			Assert.NotNull (component.room.Id);
+			Assert.NotNull (component.room.SessionId);
 		};
 
-		/*
 		component.room.OnStateChange += (object sender, StateChangeEventArgs e) => {
-			Assert.NotNull (component.room.state ["players"]);
-			Assert.NotNull (component.room.state ["messages"]);
+			Assert.NotNull (component.room.State ["players"]);
+			Assert.NotNull (component.room.State ["messages"]);
 		};
-		*/
 	}
 }

--- a/Assets/Tests/RoomTest.cs
+++ b/Assets/Tests/RoomTest.cs
@@ -28,9 +28,11 @@ public class RoomTest {
 			Assert.NotNull (component.room.sessionId);
 		};
 
+		/*
 		component.room.OnStateChange += (object sender, StateChangeEventArgs e) => {
 			Assert.NotNull (component.room.state ["players"]);
 			Assert.NotNull (component.room.state ["messages"]);
 		};
+		*/
 	}
 }

--- a/Assets/Tests/RoomTest.cs
+++ b/Assets/Tests/RoomTest.cs
@@ -18,7 +18,7 @@ public class RoomTest {
 		yield return new WaitForFixedUpdate();
 
 		component.client.OnOpen += (object sender, System.EventArgs e) => {
-			Assert.NotNull (component.client.id);
+			Assert.NotNull (component.client.Id);
 		};
 
 		yield return new WaitForSeconds(0.1f);

--- a/README.md
+++ b/README.md
@@ -17,81 +17,9 @@
     <img src="https://img.shields.io/discord/525739117951320081.svg?style=for-the-badge&colorB=7581dc&logo=discord&logoColor=white">
   </a>
   <h3>
-     Multiplayer Game Client for <a href="https://unity3d.com/">Unity</a>. <br /><a href="http://colyseus.io/docs/">View documentation</a>
+     Multiplayer Game Client for <a href="https://unity3d.com/">Unity</a>. <br /><a href="https://docs.colyseus.io/getting-started/unity3d-client/">View documentation</a>
   </h3>
 </div>
-
-## Installation
-
-Copy `Assets/Plugins` into your Unity project.
-
-## Running the demo server
-
-Ensure you have [Node v6+](http://nodejs.org/) installed. Then run these
-commands in your commandline:
-
-```
-cd Server
-npm install
-npm start
-```
-
-## Usage
-
-You'll need to start a coroutine for each WebSocket connection with the server.
-See [usage example](Assets/ColyseusClient.cs) for more details.
-
-```csharp
-Client colyseus = new Colyseus.Client ("ws://localhost:2657");
-
-Room room = colyseus.Join ("room_name");
-room.OnStateChange += OnStateChange;
-```
-
-**Getting the full room state**
-
-```csharp
-void OnStateChange (object sender, RoomUpdateEventArgs e)
-{
-	if (e.isFirstState) {
-		// First setup of your client state
-		Debug.Log(e.state);
-	} else {
-		// Further updates on your client state
-		Debug.Log(e.state);
-	}
-}
-```
-
-**Listening to add/remove on a specific key on the room state**
-
-```csharp
-room.Listen ("players/:id", OnPlayerChange);
-```
-
-```csharp
-void OnPlayerChange (DataChange change)
-{
-	Debug.Log (change.path["id"]);
-	Debug.Log (change.operation); // "add" or "remove"
-	Debug.Log (change.value); // the player object
-}
-```
-
-**Listening to specific data changes in the state**
-
-```csharp
-room.Listen ("players/:id/:axis", OnPlayerMove);
-```
-
-```csharp
-void OnPlayerMove (DataChange change)
-{
-	Debug.Log ("OnPlayerMove");
-	Debug.Log ("playerId: " + change.path["id"] + ", axis: " + change.path["axis"]);
-	Debug.Log (change.value);
-}
-```
 
 ## License
 

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -3,18 +3,15 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@colyseus/schema": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@colyseus/schema/-/schema-0.3.2.tgz",
+      "integrity": "sha512-O5F52zFFCioXS531QOgs4lpzHQcj+kZM4Hv1bvQW6PnNgtstTJKsF8wwDzNLQodvGwMYF4vutKaj/mFaQ9207w=="
+    },
     "@gamestdio/clock": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@gamestdio/clock/-/clock-1.1.9.tgz",
       "integrity": "sha1-d+wMAROR+7/ctPMhEkKVNv2GgMs="
-    },
-    "@gamestdio/timeline": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@gamestdio/timeline/-/timeline-0.3.5.tgz",
-      "integrity": "sha1-Nf++FiFTW0HftdUAnExSMBu7H8Y=",
-      "requires": {
-        "harmony-proxy": "^1.0.1"
-      }
     },
     "@gamestdio/timer": {
       "version": "1.3.0",
@@ -541,12 +538,12 @@
       "dev": true
     },
     "colyseus": {
-      "version": "0.9.33",
-      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.9.33.tgz",
-      "integrity": "sha512-ZzUwrY7AujS8ZwUeVFU/tHnQxIIq4Hy3aVF6HHg1hUTTcO4FQvq8smUOd0nIRzMMdprfD7WMuD5fEI4ymRBHjg==",
+      "version": "0.10.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.10.0-alpha.7.tgz",
+      "integrity": "sha512-9j4O+YJZhFjltboBgRdqdjBW44Jl9IFyEan64PFxiDCgPVoCu/32U0B0mUiYSOjYxkHixqpRzWQ0YjNm7/6psw==",
       "requires": {
-        "@gamestdio/timeline": "^0.3.5",
-        "@gamestdio/timer": "^1.1.7",
+        "@colyseus/schema": "^0.3.2",
+        "@gamestdio/timer": "^1.3.0",
         "@types/ws": "^6.0.1",
         "debug": "^4.0.1",
         "fast-json-patch": "^2.0.5",
@@ -2117,11 +2114,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "harmony-proxy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/harmony-proxy/-/harmony-proxy-1.0.1.tgz",
-      "integrity": "sha1-e+yPsZga8y+/wUIz4IC+Q+X3vPo="
     },
     "has-ansi": {
       "version": "2.0.0",

--- a/Server/package.json
+++ b/Server/package.json
@@ -12,7 +12,7 @@
     "node": ">= 5.x"
   },
   "dependencies": {
-    "colyseus": "^0.9.33",
+    "colyseus": "^0.10.0-alpha.7",
     "express": "^4.13.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull-request allows the colyseus-unity3d client to communicate with the latest changes on Colyseus protocol (`colyseus@alpha`). It **does not** include `@colyseus/schema` serialization support yet.

It also includes some refactoring that creates breaking changes, which are described below.

## Breaking changes

The breaking changes are mostly lowercase properties now following C# coding
standards.

- `client.id` has been renamed to `client.Id`
- `room.id` has been renamed to `room.Id`
- `room.name` has been renamed to `room.Name`
- `room.sessionId` has been renamed to `room.SessionId`
- `room.state` has been renamed to `room.State`
- `e.message` has been renamed to `e.Message` (on `MessageEventArgs` and `ErrorEventArgs`)
- `RoomUpdateEventArgs` has been renamed to `StateChangeEventArgs`
    - `e.state` has been renamed to `e.State`