### PR TITLE
better ping - reading all messages in one frame instead of one message a frame

### DIFF
--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -73,10 +73,11 @@ namespace Colyseus
 		public void Recv()
 		{
 			byte[] data = connection.Recv();
-			if (data != null)
-			{
-				ParseMessage(data);
-			}
+            while (data != null)
+            {
+                ParseMessage(data);
+                data = connection.Recv();
+            }
 
 			// TODO: this may not be a good idea?
 			foreach (var room in rooms) {

--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -103,13 +103,15 @@ namespace Colyseus
 		}
 
 		public void Recv ()
-		{
-			byte[] data = Connection.Recv();
-			if (data != null)
-			{
-				ParseMessage(data);
-			}
-		}
+        {
+            DateTime start = DateTime.Now;
+            byte[] data = Connection.Recv();
+            while (data != null && (DateTime.Now-start).TotalMilliseconds < 100)
+            {
+                ParseMessage(data);
+                data = Connection.Recv();
+            }
+        }
 
 		public IEnumerator Connect()
 		{

--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -104,9 +104,8 @@ namespace Colyseus
 
 		public void Recv ()
         {
-            DateTime start = DateTime.Now;
             byte[] data = Connection.Recv();
-            while (data != null && (DateTime.Now-start).TotalMilliseconds < 100)
+            while (data != null)
             {
                 ParseMessage(data);
                 data = Connection.Recv();


### PR DESCRIPTION
Changed Recv to read all messages instead of one in a frame.
as discussed in discord.
It improved the ping in our game.

Another possible improvement, in the same manner, would be to parse the messages right away here:
https://github.com/colyseus/colyseus-unity3d/blob/adde79f0bdb1bda68fa79af90e363ee036fc0ef4/Assets/Plugins/WebSocket/WebSocket.cs#L234
and not on Recv(which might slow the update and fps).