### PR TITLE
fixes invalid cast error

### DIFF
--- a/Assets/Plugins/Colyseus/Serializer/Schema/Schema.cs
+++ b/Assets/Plugins/Colyseus/Serializer/Schema/Schema.cs
@@ -381,18 +381,18 @@ namespace Colyseus.Schema
 
     public void ForEach (Action<string, T> action)
     {
-      foreach (KeyValuePair<string, T> item in Items)
+      foreach (DictionaryEntry item in Items)
       {
-        action(item.Key, item.Value);
+        action((string)item.Key, (T)item.Value);
       }
     }
 
     public void TriggerAll()
     {
       if (OnAdd == null) { return; }
-      foreach(KeyValuePair<string, T> entry in Items)
+      foreach(DictionaryEntry item in Items)
       {
-        OnAdd.Invoke(this, new KeyValueEventArgs<T, string>(entry.Value, entry.Key));
+        OnAdd.Invoke(this, new KeyValueEventArgs<T, string>((T)item.Value, (string)item.Key));
       }
     }
 


### PR DESCRIPTION
It looks like this code may have been copied from SchemaArray, but the internal item store doesn't use the same iteration class for items. I'm not super familiar with this class, but here is my fix, which seems to work.