### PR TITLE
websocket stabilize - format code

### DIFF
--- a/Assets/Plugins/WebSocket/WebSocket.cs
+++ b/Assets/Plugins/WebSocket/WebSocket.cs
@@ -1,657 +1,570 @@
 using System;
-using System.IO;
-using System.Net.WebSockets;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Text;
-
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Net.WebSockets;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using AOT;
-
 using UnityEngine;
 
-namespace NativeWebSocket
-{
-	public delegate void WebSocketOpenEventHandler();
-	public delegate void WebSocketMessageEventHandler(byte[] data);
-	public delegate void WebSocketErrorEventHandler(string errorMsg);
-	public delegate void WebSocketCloseEventHandler(WebSocketCloseCode closeCode);
+namespace NativeWebSocket {
+  public delegate void WebSocketOpenEventHandler ();
+  public delegate void WebSocketMessageEventHandler (byte[] data);
+  public delegate void WebSocketErrorEventHandler (string errorMsg);
+  public delegate void WebSocketCloseEventHandler (WebSocketCloseCode closeCode);
 
-	public enum WebSocketCloseCode
-	{
-		/* Do NOT use NotSet - it's only purpose is to indicate that the close code cannot be parsed. */
-		NotSet = 0,
-		Normal = 1000,
-		Away = 1001,
-		ProtocolError = 1002,
-		UnsupportedData = 1003,
-		Undefined = 1004,
-		NoStatus = 1005,
-		Abnormal = 1006,
-		InvalidData = 1007,
-		PolicyViolation = 1008,
-		TooBig = 1009,
-		MandatoryExtension = 1010,
-		ServerError = 1011,
-		TlsHandshakeFailure = 1015
-	}
+  public enum WebSocketCloseCode {
+    /* Do NOT use NotSet - it's only purpose is to indicate that the close code cannot be parsed. */
+    NotSet = 0,
+    Normal = 1000,
+    Away = 1001,
+    ProtocolError = 1002,
+    UnsupportedData = 1003,
+    Undefined = 1004,
+    NoStatus = 1005,
+    Abnormal = 1006,
+    InvalidData = 1007,
+    PolicyViolation = 1008,
+    TooBig = 1009,
+    MandatoryExtension = 1010,
+    ServerError = 1011,
+    TlsHandshakeFailure = 1015
+  }
 
-	public enum WebSocketState
-	{
-		Connecting,
-		Open,
-		Closing,
-		Closed
-	}
+  public enum WebSocketState {
+    Connecting,
+    Open,
+    Closing,
+    Closed
+  }
 
-	public interface IWebSocket
-	{
-		event WebSocketOpenEventHandler OnOpen;
-		event WebSocketMessageEventHandler OnMessage;
-		event WebSocketErrorEventHandler OnError;
-		event WebSocketCloseEventHandler OnClose;
+  public interface IWebSocket {
+    event WebSocketOpenEventHandler OnOpen;
+    event WebSocketMessageEventHandler OnMessage;
+    event WebSocketErrorEventHandler OnError;
+    event WebSocketCloseEventHandler OnClose;
 
-		WebSocketState State { get; }
-	}
+    WebSocketState State { get; }
+  }
 
+  public static class WebSocketHelpers {
+    public static WebSocketCloseCode ParseCloseCodeEnum (int closeCode) {
 
-	public static class WebSocketHelpers
-	{
-		public static WebSocketCloseCode ParseCloseCodeEnum(int closeCode)
-		{
-
-			if (WebSocketCloseCode.IsDefined(typeof(WebSocketCloseCode), closeCode))
-			{
-				return (WebSocketCloseCode)closeCode;
-			}
-			else
-			{
-				return WebSocketCloseCode.Undefined;
-			}
-
-		}
-
-		public static WebSocketException GetErrorMessageFromCode(int errorCode, Exception inner)
-		{
-			switch (errorCode)
-			{
-				case -1: return new WebSocketUnexpectedException("WebSocket instance not found.", inner);
-				case -2: return new WebSocketInvalidStateException("WebSocket is already connected or in connecting state.", inner);
-				case -3: return new WebSocketInvalidStateException("WebSocket is not connected.", inner);
-				case -4: return new WebSocketInvalidStateException("WebSocket is already closing.", inner);
-				case -5: return new WebSocketInvalidStateException("WebSocket is already closed.", inner);
-				case -6: return new WebSocketInvalidStateException("WebSocket is not in open state.", inner);
-				case -7: return new WebSocketInvalidArgumentException("Cannot close WebSocket. An invalid code was specified or reason is too long.", inner);
-				default: return new WebSocketUnexpectedException("Unknown error.", inner);
-			}
-		}
-	}
-
-	public class WebSocketException : Exception
-	{
-		public WebSocketException() { }
-		public WebSocketException(string message) : base(message) { }
-		public WebSocketException(string message, Exception inner) : base(message, inner) { }
-	}
-
-	public class WebSocketUnexpectedException : WebSocketException
-	{
-		public WebSocketUnexpectedException() { }
-		public WebSocketUnexpectedException(string message) : base(message) { }
-		public WebSocketUnexpectedException(string message, Exception inner) : base(message, inner) { }
-	}
-
-	public class WebSocketInvalidArgumentException : WebSocketException
-	{
-		public WebSocketInvalidArgumentException() { }
-		public WebSocketInvalidArgumentException(string message) : base(message) { }
-		public WebSocketInvalidArgumentException(string message, Exception inner) : base(message, inner) { }
-	}
-
-	public class WebSocketInvalidStateException : WebSocketException
-	{
-		public WebSocketInvalidStateException() { }
-		public WebSocketInvalidStateException(string message) : base(message) { }
-		public WebSocketInvalidStateException(string message, Exception inner) : base(message, inner) { }
-	}
-
-
-#if UNITY_WEBGL && !UNITY_EDITOR
-
-   /// <summary>
-    /// WebSocket class bound to JSLIB.
-    /// </summary>
-    public class WebSocket : IWebSocket
-    {
-
-        /* WebSocket JSLIB functions */
-        [DllImport("__Internal")]
-        public static extern int WebSocketConnect(int instanceId);
-
-        [DllImport("__Internal")]
-        public static extern int WebSocketClose(int instanceId, int code, string reason);
-
-        [DllImport("__Internal")]
-        public static extern int WebSocketSend(int instanceId, byte[] dataPtr, int dataLength);
-
-        [DllImport("__Internal")]
-        public static extern int WebSocketSendText(int instanceId, string message);
-
-        [DllImport("__Internal")]
-        public static extern int WebSocketGetState(int instanceId);
-
-        protected int instanceId;
-
-        public event WebSocketOpenEventHandler OnOpen;
-        public event WebSocketMessageEventHandler OnMessage;
-        public event WebSocketErrorEventHandler OnError;
-        public event WebSocketCloseEventHandler OnClose;
-
-        public WebSocket(string url)
-        {
-          if (!WebSocketFactory.isInitialized) {
-            WebSocketFactory.Initialize();
-          }
-
-        	int instanceId = WebSocketFactory.WebSocketAllocate(url);
-        	WebSocketFactory.instances.Add(instanceId, this);
-
-            this.instanceId = instanceId;
-        }
-
-        ~WebSocket()
-        {
-            WebSocketFactory.HandleInstanceDestroy(this.instanceId);
-        }
-
-        public int GetInstanceId()
-        {
-            return this.instanceId;
-        }
-
-        public Task Connect()
-        {
-            int ret = WebSocketConnect(this.instanceId);
-
-            if (ret < 0)
-                throw WebSocketHelpers.GetErrorMessageFromCode(ret, null);
-
-            return Task.CompletedTask;
-        }
-
-        public Task Close(WebSocketCloseCode code = WebSocketCloseCode.Normal, string reason = null)
-        {
-            int ret = WebSocketClose(this.instanceId, (int)code, reason);
-
-            if (ret < 0)
-                throw WebSocketHelpers.GetErrorMessageFromCode(ret, null);
-
-            return Task.CompletedTask;
-        }
-
-        public Task Send(byte[] data)
-        {
-            int ret = WebSocketSend(this.instanceId, data, data.Length);
-
-            if (ret < 0)
-                throw WebSocketHelpers.GetErrorMessageFromCode(ret, null);
-
-            return Task.CompletedTask;
-        }
-
-        public Task SendText(string message)
-        {
-            int ret = WebSocketSendText(this.instanceId, message);
-
-            if (ret < 0)
-                throw WebSocketHelpers.GetErrorMessageFromCode(ret, null);
-
-            return Task.CompletedTask;
-        }
-
-        public WebSocketState State {
-            get {
-                int state = WebSocketGetState(this.instanceId);
-
-                if (state < 0)
-                    throw WebSocketHelpers.GetErrorMessageFromCode(state, null);
-
-                switch (state)
-                {
-                    case 0:
-                        return WebSocketState.Connecting;
-
-                    case 1:
-                        return WebSocketState.Open;
-
-                    case 2:
-                        return WebSocketState.Closing;
-
-                    case 3:
-                        return WebSocketState.Closed;
-
-                    default:
-                        return WebSocketState.Closed;
-                }
-            }
-        }
-
-        public void DelegateOnOpenEvent()
-        {
-            this.OnOpen?.Invoke();
-        }
-
-        public void DelegateOnMessageEvent(byte[] data)
-        {
-            this.OnMessage?.Invoke(data);
-        }
-
-        public void DelegateOnErrorEvent(string errorMsg)
-        {
-            this.OnError?.Invoke(errorMsg);
-        }
-
-        public void DelegateOnCloseEvent(int closeCode)
-        {
-            this.OnClose?.Invoke(WebSocketHelpers.ParseCloseCodeEnum(closeCode));
-        }
+      if (WebSocketCloseCode.IsDefined (typeof (WebSocketCloseCode), closeCode)) {
+        return (WebSocketCloseCode) closeCode;
+      } else {
+        return WebSocketCloseCode.Undefined;
+      }
 
     }
 
+    public static WebSocketException GetErrorMessageFromCode (int errorCode, Exception inner) {
+      switch (errorCode) {
+        case -1:
+          return new WebSocketUnexpectedException ("WebSocket instance not found.", inner);
+        case -2:
+          return new WebSocketInvalidStateException ("WebSocket is already connected or in connecting state.", inner);
+        case -3:
+          return new WebSocketInvalidStateException ("WebSocket is not connected.", inner);
+        case -4:
+          return new WebSocketInvalidStateException ("WebSocket is already closing.", inner);
+        case -5:
+          return new WebSocketInvalidStateException ("WebSocket is already closed.", inner);
+        case -6:
+          return new WebSocketInvalidStateException ("WebSocket is not in open state.", inner);
+        case -7:
+          return new WebSocketInvalidArgumentException ("Cannot close WebSocket. An invalid code was specified or reason is too long.", inner);
+        default:
+          return new WebSocketUnexpectedException ("Unknown error.", inner);
+      }
+    }
+  }
+
+  public class WebSocketException : Exception {
+    public WebSocketException () { }
+    public WebSocketException (string message) : base (message) { }
+    public WebSocketException (string message, Exception inner) : base (message, inner) { }
+  }
+
+  public class WebSocketUnexpectedException : WebSocketException {
+    public WebSocketUnexpectedException () { }
+    public WebSocketUnexpectedException (string message) : base (message) { }
+    public WebSocketUnexpectedException (string message, Exception inner) : base (message, inner) { }
+  }
+
+  public class WebSocketInvalidArgumentException : WebSocketException {
+    public WebSocketInvalidArgumentException () { }
+    public WebSocketInvalidArgumentException (string message) : base (message) { }
+    public WebSocketInvalidArgumentException (string message, Exception inner) : base (message, inner) { }
+  }
+
+  public class WebSocketInvalidStateException : WebSocketException {
+    public WebSocketInvalidStateException () { }
+    public WebSocketInvalidStateException (string message) : base (message) { }
+    public WebSocketInvalidStateException (string message, Exception inner) : base (message, inner) { }
+  }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+
+  /// <summary>
+  /// WebSocket class bound to JSLIB.
+  /// </summary>
+  public class WebSocket : IWebSocket {
+
+    /* WebSocket JSLIB functions */
+    [DllImport ("__Internal")]
+    public static extern int WebSocketConnect (int instanceId);
+
+    [DllImport ("__Internal")]
+    public static extern int WebSocketClose (int instanceId, int code, string reason);
+
+    [DllImport ("__Internal")]
+    public static extern int WebSocketSend (int instanceId, byte[] dataPtr, int dataLength);
+
+    [DllImport ("__Internal")]
+    public static extern int WebSocketSendText (int instanceId, string message);
+
+    [DllImport ("__Internal")]
+    public static extern int WebSocketGetState (int instanceId);
+
+    protected int instanceId;
+
+    public event WebSocketOpenEventHandler OnOpen;
+    public event WebSocketMessageEventHandler OnMessage;
+    public event WebSocketErrorEventHandler OnError;
+    public event WebSocketCloseEventHandler OnClose;
+
+    public WebSocket (string url) {
+      if (!WebSocketFactory.isInitialized) {
+        WebSocketFactory.Initialize ();
+      }
+
+      int instanceId = WebSocketFactory.WebSocketAllocate (url);
+      WebSocketFactory.instances.Add (instanceId, this);
+
+      this.instanceId = instanceId;
+    }
+
+    ~WebSocket () {
+      WebSocketFactory.HandleInstanceDestroy (this.instanceId);
+    }
+
+    public int GetInstanceId () {
+      return this.instanceId;
+    }
+
+    public Task Connect () {
+      int ret = WebSocketConnect (this.instanceId);
+
+      if (ret < 0)
+        throw WebSocketHelpers.GetErrorMessageFromCode (ret, null);
+
+      return Task.CompletedTask;
+    }
+
+    public Task Close (WebSocketCloseCode code = WebSocketCloseCode.Normal, string reason = null) {
+      int ret = WebSocketClose (this.instanceId, (int) code, reason);
+
+      if (ret < 0)
+        throw WebSocketHelpers.GetErrorMessageFromCode (ret, null);
+
+      return Task.CompletedTask;
+    }
+
+    public Task Send (byte[] data) {
+      int ret = WebSocketSend (this.instanceId, data, data.Length);
+
+      if (ret < 0)
+        throw WebSocketHelpers.GetErrorMessageFromCode (ret, null);
+
+      return Task.CompletedTask;
+    }
+
+    public Task SendText (string message) {
+      int ret = WebSocketSendText (this.instanceId, message);
+
+      if (ret < 0)
+        throw WebSocketHelpers.GetErrorMessageFromCode (ret, null);
+
+      return Task.CompletedTask;
+    }
+
+    public WebSocketState State {
+      get {
+        int state = WebSocketGetState (this.instanceId);
+
+        if (state < 0)
+          throw WebSocketHelpers.GetErrorMessageFromCode (state, null);
+
+        switch (state) {
+          case 0:
+            return WebSocketState.Connecting;
+
+          case 1:
+            return WebSocketState.Open;
+
+          case 2:
+            return WebSocketState.Closing;
+
+          case 3:
+            return WebSocketState.Closed;
+
+          default:
+            return WebSocketState.Closed;
+        }
+      }
+    }
+
+    public void DelegateOnOpenEvent () {
+      this.OnOpen?.Invoke ();
+    }
+
+    public void DelegateOnMessageEvent (byte[] data) {
+      this.OnMessage?.Invoke (data);
+    }
+
+    public void DelegateOnErrorEvent (string errorMsg) {
+      this.OnError?.Invoke (errorMsg);
+    }
+
+    public void DelegateOnCloseEvent (int closeCode) {
+      this.OnClose?.Invoke (WebSocketHelpers.ParseCloseCodeEnum (closeCode));
+    }
+
+  }
 
 #else
 
-  public class WebSocket : IWebSocket
-	{
-		public event WebSocketOpenEventHandler OnOpen;
-		public event WebSocketMessageEventHandler OnMessage;
-		public event WebSocketErrorEventHandler OnError;
-		public event WebSocketCloseEventHandler OnClose;
+  public class WebSocket : IWebSocket {
+    public event WebSocketOpenEventHandler OnOpen;
+    public event WebSocketMessageEventHandler OnMessage;
+    public event WebSocketErrorEventHandler OnError;
+    public event WebSocketCloseEventHandler OnClose;
 
-		private Uri uri;
-		private ClientWebSocket m_Socket = new ClientWebSocket();
+    private Uri uri;
+    private ClientWebSocket m_Socket = new ClientWebSocket ();
 
     private CancellationTokenSource m_TokenSource;
     private CancellationToken m_CancellationToken;
 
-    private readonly object Lock = new object();
+    private readonly object Lock = new object ();
 
     private bool isSending = false;
-    private List<ArraySegment<byte>> sendBytesQueue = new List<ArraySegment<byte>>();
-    private List<ArraySegment<byte>> sendTextQueue = new List<ArraySegment<byte>>();
+    private List<ArraySegment<byte>> sendBytesQueue = new List<ArraySegment<byte>> ();
+    private List<ArraySegment<byte>> sendTextQueue = new List<ArraySegment<byte>> ();
 
-    public WebSocket(string url)
-		{
-			uri = new Uri(url);
+    public WebSocket (string url) {
+      uri = new Uri (url);
 
-			string protocol = uri.Scheme;
-			if (!protocol.Equals("ws") && !protocol.Equals("wss"))
-				throw new ArgumentException("Unsupported protocol: " + protocol);
-		}
-
-    public void CancelConnection()
-    {
-	    m_TokenSource?.Cancel();
+      string protocol = uri.Scheme;
+      if (!protocol.Equals ("ws") && !protocol.Equals ("wss"))
+        throw new ArgumentException ("Unsupported protocol: " + protocol);
     }
 
-		public async Task Connect()
-		{
-			try
-			{
-				m_TokenSource = new CancellationTokenSource();
-				m_CancellationToken = m_TokenSource.Token;
+    public void CancelConnection () {
+      m_TokenSource?.Cancel ();
+    }
 
-				m_Socket = new ClientWebSocket();
+    public async Task Connect () {
+      try {
+        m_TokenSource = new CancellationTokenSource ();
+        m_CancellationToken = m_TokenSource.Token;
 
-				await m_Socket.ConnectAsync(uri, m_CancellationToken);
-				OnOpen?.Invoke();
+        m_Socket = new ClientWebSocket ();
 
-				await Receive();
-			}
-			catch (Exception ex)
-			{
-				OnError?.Invoke(ex.Message);
-				OnClose?.Invoke(WebSocketCloseCode.Abnormal);
-			}
-			finally
-			{
-				if (m_Socket != null)
-				{
-					m_TokenSource.Cancel();
-					m_Socket.Dispose();
-				}
-			}
-		}
+        await m_Socket.ConnectAsync (uri, m_CancellationToken);
+        OnOpen?.Invoke ();
 
-		public WebSocketState State
-		{
-			get
-			{
-				switch (m_Socket.State)
-				{
-					case System.Net.WebSockets.WebSocketState.Connecting:
-						return WebSocketState.Connecting;
+        await Receive ();
+      } catch (Exception ex) {
+        OnError?.Invoke (ex.Message);
+        OnClose?.Invoke (WebSocketCloseCode.Abnormal);
+      } finally {
+        if (m_Socket != null) {
+          m_TokenSource.Cancel ();
+          m_Socket.Dispose ();
+        }
+      }
+    }
 
-					case System.Net.WebSockets.WebSocketState.Open:
-						return WebSocketState.Open;
+    public WebSocketState State {
+      get {
+        switch (m_Socket.State) {
+          case System.Net.WebSockets.WebSocketState.Connecting:
+            return WebSocketState.Connecting;
 
-					case System.Net.WebSockets.WebSocketState.CloseSent:
-					case System.Net.WebSockets.WebSocketState.CloseReceived:
-						return WebSocketState.Closing;
+          case System.Net.WebSockets.WebSocketState.Open:
+            return WebSocketState.Open;
 
-					case System.Net.WebSockets.WebSocketState.Closed:
-						return WebSocketState.Closed;
+          case System.Net.WebSockets.WebSocketState.CloseSent:
+          case System.Net.WebSockets.WebSocketState.CloseReceived:
+            return WebSocketState.Closing;
 
-					default:
-						return WebSocketState.Closed;
-				}
-			}
-		}
+          case System.Net.WebSockets.WebSocketState.Closed:
+            return WebSocketState.Closed;
 
-		public Task Send(byte[] bytes)
-		{
+          default:
+            return WebSocketState.Closed;
+        }
+      }
+    }
+
+    public Task Send (byte[] bytes) {
       // return m_Socket.SendAsync(buffer, WebSocketMessageType.Binary, true, CancellationToken.None);
-      return SendMessage(sendBytesQueue, WebSocketMessageType.Binary, new ArraySegment<byte>(bytes));
-		}
+      return SendMessage (sendBytesQueue, WebSocketMessageType.Binary, new ArraySegment<byte> (bytes));
+    }
 
-		public Task SendText(string message)
-		{
-			var encoded = Encoding.UTF8.GetBytes(message);
+    public Task SendText (string message) {
+      var encoded = Encoding.UTF8.GetBytes (message);
 
       // m_Socket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
-      return SendMessage(sendTextQueue, WebSocketMessageType.Text, new ArraySegment<byte>(encoded, 0, encoded.Length));
+      return SendMessage (sendTextQueue, WebSocketMessageType.Text, new ArraySegment<byte> (encoded, 0, encoded.Length));
     }
 
-    private async Task SendMessage(List<ArraySegment<byte>> queue, WebSocketMessageType messageType, ArraySegment<byte> buffer)
-    {
+    private async Task SendMessage (List<ArraySegment<byte>> queue, WebSocketMessageType messageType, ArraySegment<byte> buffer) {
       // Return control to the calling method immediately.
-      await Task.Yield();
+      await Task.Yield ();
 
       // Make sure we have data.
-      if (buffer.Count == 0)
-      {
+      if (buffer.Count == 0) {
         return;
       }
 
       // The state of the connection is contained in the context Items dictionary.
       bool sending;
 
-      lock (Lock)
-      {
+      lock (Lock) {
         sending = isSending;
 
         // If not, we are now.
-        if (!isSending)
-        {
+        if (!isSending) {
           isSending = true;
         }
       }
 
-      if (!sending)
-      {
+      if (!sending) {
         // Lock with a timeout, just in case.
-        if (!Monitor.TryEnter(m_Socket, 1000))
-        {
+        if (!Monitor.TryEnter (m_Socket, 1000)) {
           // If we couldn't obtain exclusive access to the socket in one second, something is wrong.
-          await m_Socket.CloseAsync(WebSocketCloseStatus.InternalServerError, string.Empty, m_CancellationToken);
+          await m_Socket.CloseAsync (WebSocketCloseStatus.InternalServerError, string.Empty, m_CancellationToken);
           return;
         }
 
-        try
-        {
+        try {
           // Send the message synchronously.
-          var t = m_Socket.SendAsync(buffer, messageType, true, m_CancellationToken);
-          t.Wait(m_CancellationToken);
-        }
-        finally
-        {
-          Monitor.Exit(m_Socket);
+          var t = m_Socket.SendAsync (buffer, messageType, true, m_CancellationToken);
+          t.Wait (m_CancellationToken);
+        } finally {
+          Monitor.Exit (m_Socket);
         }
 
         // Note that we've finished sending.
-        lock (Lock)
-        {
+        lock (Lock) {
           isSending = false;
         }
 
         // Handle any queued messages.
-        await HandleQueue(queue, messageType);
-      }
-      else
-      {
+        await HandleQueue (queue, messageType);
+      } else {
         // Add the message to the queue.
-        lock (Lock)
-        {
-          queue.Add(buffer);
+        lock (Lock) {
+          queue.Add (buffer);
         }
       }
     }
 
-    private async Task HandleQueue(List<ArraySegment<byte>> queue, WebSocketMessageType messageType)
-    {
-      var buffer = new ArraySegment<byte>();
-      lock (Lock)
-      {
+    private async Task HandleQueue (List<ArraySegment<byte>> queue, WebSocketMessageType messageType) {
+      var buffer = new ArraySegment<byte> ();
+      lock (Lock) {
         // Check for an item in the queue.
-        if (queue.Count > 0)
-        {
+        if (queue.Count > 0) {
           // Pull it off the top.
           buffer = queue[0];
-          queue.RemoveAt(0);
+          queue.RemoveAt (0);
         }
       }
 
       // Send that message.
-      if (buffer.Count > 0)
-      {
-        await SendMessage(queue, messageType, buffer);
+      if (buffer.Count > 0) {
+        await SendMessage (queue, messageType, buffer);
       }
     }
 
-
-    public async Task Receive()
-		{
-			ArraySegment<byte> buffer = new ArraySegment<byte>(new byte[8192]);
-			try
-			{
-        while (m_Socket.State == System.Net.WebSockets.WebSocketState.Open)
-        {
+    public async Task Receive () {
+      ArraySegment<byte> buffer = new ArraySegment<byte> (new byte[8192]);
+      try {
+        while (m_Socket.State == System.Net.WebSockets.WebSocketState.Open) {
           WebSocketReceiveResult result = null;
 
-          using (var ms = new MemoryStream())
-          {
-            do
-            {
-              result = await m_Socket.ReceiveAsync(buffer, m_CancellationToken);
-              ms.Write(buffer.Array, buffer.Offset, result.Count);
+          using (var ms = new MemoryStream ()) {
+            do {
+              result = await m_Socket.ReceiveAsync (buffer, m_CancellationToken);
+              ms.Write (buffer.Array, buffer.Offset, result.Count);
             }
             while (!result.EndOfMessage);
 
-            ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek (0, SeekOrigin.Begin);
 
-            if (result.MessageType == WebSocketMessageType.Text)
-            {
-              OnMessage?.Invoke(ms.ToArray());
+            if (result.MessageType == WebSocketMessageType.Text) {
+              OnMessage?.Invoke (ms.ToArray ());
               //using (var reader = new StreamReader(ms, Encoding.UTF8))
               //{
               //	string message = reader.ReadToEnd();
               //	OnMessage?.Invoke(this, new MessageEventArgs(message));
               //}
-            }
-            else if (result.MessageType == WebSocketMessageType.Binary)
-            {
-              OnMessage?.Invoke(ms.ToArray());
-            }
-            else if (result.MessageType == WebSocketMessageType.Close)
-            {
-              await Close();
-              OnClose?.Invoke(WebSocketHelpers.ParseCloseCodeEnum((int)result.CloseStatus));
+            } else if (result.MessageType == WebSocketMessageType.Binary) {
+              OnMessage?.Invoke (ms.ToArray ());
+            } else if (result.MessageType == WebSocketMessageType.Close) {
+              await Close ();
+              OnClose?.Invoke (WebSocketHelpers.ParseCloseCodeEnum ((int) result.CloseStatus));
               break;
             }
           }
         }
+      } catch (Exception e) {
+        m_TokenSource.Cancel ();
+        OnClose?.Invoke (WebSocketCloseCode.Abnormal);
       }
-			catch (Exception e)
-			{
-				m_TokenSource.Cancel();
-				OnClose?.Invoke(WebSocketCloseCode.Abnormal);
-			}
-		}
+    }
 
-		public async Task Close()
-		{
-			if (State == WebSocketState.Open)
-			{
-				await m_Socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, m_CancellationToken);
-			}
-		}
-	}
+    public async Task Close () {
+      if (State == WebSocketState.Open) {
+        await m_Socket.CloseAsync (WebSocketCloseStatus.NormalClosure, string.Empty, m_CancellationToken);
+      }
+    }
+  }
 #endif
 
+  ///
+  /// Factory
+  ///
 
-	///
-	/// Factory
-	///
-
-
-	/// <summary>
-	/// Class providing static access methods to work with JSLIB WebSocket or WebSocketSharp interface
-	/// </summary>
-	public static class WebSocketFactory
-	{
+  /// <summary>
+  /// Class providing static access methods to work with JSLIB WebSocket or WebSocketSharp interface
+  /// </summary>
+  public static class WebSocketFactory {
 
 #if UNITY_WEBGL && !UNITY_EDITOR
-        /* Map of websocket instances */
-        public static Dictionary<Int32, WebSocket> instances = new Dictionary<Int32, WebSocket>();
+    /* Map of websocket instances */
+    public static Dictionary<Int32, WebSocket> instances = new Dictionary<Int32, WebSocket> ();
 
-        /* Delegates */
-        public delegate void OnOpenCallback(int instanceId);
-        public delegate void OnMessageCallback(int instanceId, System.IntPtr msgPtr, int msgSize);
-        public delegate void OnErrorCallback(int instanceId, System.IntPtr errorPtr);
-        public delegate void OnCloseCallback(int instanceId, int closeCode);
+    /* Delegates */
+    public delegate void OnOpenCallback (int instanceId);
+    public delegate void OnMessageCallback (int instanceId, System.IntPtr msgPtr, int msgSize);
+    public delegate void OnErrorCallback (int instanceId, System.IntPtr errorPtr);
+    public delegate void OnCloseCallback (int instanceId, int closeCode);
 
-        /* WebSocket JSLIB callback setters and other functions */
-        [DllImport("__Internal")]
-        public static extern int WebSocketAllocate(string url);
+    /* WebSocket JSLIB callback setters and other functions */
+    [DllImport ("__Internal")]
+    public static extern int WebSocketAllocate (string url);
 
-        [DllImport("__Internal")]
-        public static extern void WebSocketFree(int instanceId);
+    [DllImport ("__Internal")]
+    public static extern void WebSocketFree (int instanceId);
 
-        [DllImport("__Internal")]
-        public static extern void WebSocketSetOnOpen(OnOpenCallback callback);
+    [DllImport ("__Internal")]
+    public static extern void WebSocketSetOnOpen (OnOpenCallback callback);
 
-        [DllImport("__Internal")]
-        public static extern void WebSocketSetOnMessage(OnMessageCallback callback);
+    [DllImport ("__Internal")]
+    public static extern void WebSocketSetOnMessage (OnMessageCallback callback);
 
-        [DllImport("__Internal")]
-        public static extern void WebSocketSetOnError(OnErrorCallback callback);
+    [DllImport ("__Internal")]
+    public static extern void WebSocketSetOnError (OnErrorCallback callback);
 
-        [DllImport("__Internal")]
-        public static extern void WebSocketSetOnClose(OnCloseCallback callback);
+    [DllImport ("__Internal")]
+    public static extern void WebSocketSetOnClose (OnCloseCallback callback);
 
-        /* If callbacks was initialized and set */
-        public static bool isInitialized = false;
+    /* If callbacks was initialized and set */
+    public static bool isInitialized = false;
 
-        /*
-         * Initialize WebSocket callbacks to JSLIB
-         */
-        public static void Initialize()
-        {
+    /*
+     * Initialize WebSocket callbacks to JSLIB
+     */
+    public static void Initialize () {
 
-            WebSocketSetOnOpen(DelegateOnOpenEvent);
-            WebSocketSetOnMessage(DelegateOnMessageEvent);
-            WebSocketSetOnError(DelegateOnErrorEvent);
-            WebSocketSetOnClose(DelegateOnCloseEvent);
+      WebSocketSetOnOpen (DelegateOnOpenEvent);
+      WebSocketSetOnMessage (DelegateOnMessageEvent);
+      WebSocketSetOnError (DelegateOnErrorEvent);
+      WebSocketSetOnClose (DelegateOnCloseEvent);
 
-            isInitialized = true;
+      isInitialized = true;
 
-        }
+    }
 
-        /// <summary>
-        /// Called when instance is destroyed (by destructor)
-        /// Method removes instance from map and free it in JSLIB implementation
-        /// </summary>
-        /// <param name="instanceId">Instance identifier.</param>
-        public static void HandleInstanceDestroy(int instanceId)
-        {
+    /// <summary>
+    /// Called when instance is destroyed (by destructor)
+    /// Method removes instance from map and free it in JSLIB implementation
+    /// </summary>
+    /// <param name="instanceId">Instance identifier.</param>
+    public static void HandleInstanceDestroy (int instanceId) {
 
-            instances.Remove(instanceId);
-            WebSocketFree(instanceId);
+      instances.Remove (instanceId);
+      WebSocketFree (instanceId);
 
-        }
+    }
 
-        [MonoPInvokeCallback(typeof(OnOpenCallback))]
-        public static void DelegateOnOpenEvent(int instanceId)
-        {
+    [MonoPInvokeCallback (typeof (OnOpenCallback))]
+    public static void DelegateOnOpenEvent (int instanceId) {
 
-            WebSocket instanceRef;
+      WebSocket instanceRef;
 
-            if (instances.TryGetValue(instanceId, out instanceRef))
-            {
-                instanceRef.DelegateOnOpenEvent();
-            }
+      if (instances.TryGetValue (instanceId, out instanceRef)) {
+        instanceRef.DelegateOnOpenEvent ();
+      }
 
-        }
+    }
 
-        [MonoPInvokeCallback(typeof(OnMessageCallback))]
-        public static void DelegateOnMessageEvent(int instanceId, System.IntPtr msgPtr, int msgSize)
-        {
+    [MonoPInvokeCallback (typeof (OnMessageCallback))]
+    public static void DelegateOnMessageEvent (int instanceId, System.IntPtr msgPtr, int msgSize) {
 
-            WebSocket instanceRef;
+      WebSocket instanceRef;
 
-            if (instances.TryGetValue(instanceId, out instanceRef))
-            {
-                byte[] msg = new byte[msgSize];
-                Marshal.Copy(msgPtr, msg, 0, msgSize);
+      if (instances.TryGetValue (instanceId, out instanceRef)) {
+        byte[] msg = new byte[msgSize];
+        Marshal.Copy (msgPtr, msg, 0, msgSize);
 
-                instanceRef.DelegateOnMessageEvent(msg);
-            }
+        instanceRef.DelegateOnMessageEvent (msg);
+      }
 
-        }
+    }
 
-        [MonoPInvokeCallback(typeof(OnErrorCallback))]
-        public static void DelegateOnErrorEvent(int instanceId, System.IntPtr errorPtr)
-        {
+    [MonoPInvokeCallback (typeof (OnErrorCallback))]
+    public static void DelegateOnErrorEvent (int instanceId, System.IntPtr errorPtr) {
 
-            WebSocket instanceRef;
+      WebSocket instanceRef;
 
-            if (instances.TryGetValue(instanceId, out instanceRef))
-            {
+      if (instances.TryGetValue (instanceId, out instanceRef)) {
 
-                string errorMsg = Marshal.PtrToStringAuto(errorPtr);
-                instanceRef.DelegateOnErrorEvent(errorMsg);
+        string errorMsg = Marshal.PtrToStringAuto (errorPtr);
+        instanceRef.DelegateOnErrorEvent (errorMsg);
 
-            }
+      }
 
-        }
+    }
 
-        [MonoPInvokeCallback(typeof(OnCloseCallback))]
-        public static void DelegateOnCloseEvent(int instanceId, int closeCode)
-        {
+    [MonoPInvokeCallback (typeof (OnCloseCallback))]
+    public static void DelegateOnCloseEvent (int instanceId, int closeCode) {
 
-            WebSocket instanceRef;
+      WebSocket instanceRef;
 
-            if (instances.TryGetValue(instanceId, out instanceRef))
-            {
-                instanceRef.DelegateOnCloseEvent(closeCode);
-            }
+      if (instances.TryGetValue (instanceId, out instanceRef)) {
+        instanceRef.DelegateOnCloseEvent (closeCode);
+      }
 
-        }
+    }
 #endif
 
-		/// <summary>
-		/// Create WebSocket client instance
-		/// </summary>
-		/// <returns>The WebSocket instance.</returns>
-		/// <param name="url">WebSocket valid URL.</param>
-		public static WebSocket CreateInstance(string url)
-		{
-			return new WebSocket(url);
-		}
+    /// <summary>
+    /// Create WebSocket client instance
+    /// </summary>
+    /// <returns>The WebSocket instance.</returns>
+    /// <param name="url">WebSocket valid URL.</param>
+    public static WebSocket CreateInstance (string url) {
+      return new WebSocket (url);
+    }
 
-	}
-
+  }
 
 }


### PR DESCRIPTION
The PR Goal is to stabilize the the rooms underlying WebSocket connection.

In our project my task was to improve the re-connection ability of the connection. We plan to deploy the project for mobile devices.

There are some cases, when the server closes connection, however the client still thinks the connection is at open state, or took a long time to realize a problem has occurred. Through out of my experience with the framework, I've encounters the following problems.

Most of the time the problem was, the `Room` didn't get notified about the WebSocket `connectionState` change, so the `OnLeave` event never fired.

- Client side, the user turns off the wifi manually - connection shows open state forever. My solution was to detect this state manually, then Forcefully call the `CancelConnection()`.
- Client side, the IOS device goes into lock screen, the WS state still open when the phone waked up but the server already closed the connection.
- Also resolves small annoying errors, as a result of a `Room` will get notified about the disconnect.

For the `CancelToken`
- This could help client side to forcefully close and cleanup the websockets. This ability comes handy when the Websocket stucked.

The second part of the PR is about the code formatting. You can pull this as.

**This changes tested with**
- Unity 2018.3f1
- Editor
- IOS
- Android
