### PR TITLE
[WIP] Allow custom types

### DIFF
--- a/Assets/Plugins/Colyseus/Connection.cs
+++ b/Assets/Plugins/Colyseus/Connection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -25,8 +25,12 @@ namespace Colyseus
 			OnClose += _OnClose;
 		}
 
-		public async Task Send(object[] data)
+		public async Task Send<T>(T data)
 		{
+			//Since the input is of type T we cannot assume that an object is serializable.
+			if(!data.GetType().IsSerializable)
+				throw new NotSerializableException("Object passed to Connection.Send is not serializable.");
+
 			var serializationOutput = new MemoryStream ();
 			MsgPack.Serialize (data, serializationOutput);
 

--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using GameDevWare.Serialization;
@@ -128,8 +128,12 @@ namespace Colyseus
 		/// Send data to this room.
 		/// </summary>
 		/// <param name="data">Data to be sent</param>
-		public async Task Send (object data)
+		public async Task Send<T> (T data)
 		{
+			//Since the input is of type T we cannot assume that an object is serializable.
+			if(!data.GetType().IsSerializable)
+				throw new NotSerializableException("Object passed to Connection.Send is not serializable.");
+
 			await Connection.Send(new object[]{Protocol.ROOM_DATA, data});
 		}
 

--- a/Assets/Plugins/Colyseus/Serializer/Serializer.cs
+++ b/Assets/Plugins/Colyseus/Serializer/Serializer.cs
@@ -13,4 +13,14 @@ namespace Colyseus
 	    void Teardown ();
     	void Handshake (byte[] bytes, int offset);
 	}
+
+	public class NotSerializableException : Exception
+	{
+	  public MyException() { }
+	  public MyException( string message ) : base( message ) { }
+	  public MyException( string message, Exception inner ) : base( message, inner ) { }
+	  protected MyException( 
+		System.Runtime.Serialization.SerializationInfo info, 
+		System.Runtime.Serialization.StreamingContext context ) : base( info, context ) { }
+	}
 }


### PR DESCRIPTION
Closes #89   

This will allow users to declare custom objects to send via the `room.Send(SerializableObject)`
