### PR TITLE
add build badge and how to release description

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ RELEASE_VERSION will be used for multiple things:
 - It will add this string as a suffix to attachments of the release (example: plugins-0.11.0.zip
 
 2. Check Github releases for new draft (can take a while)
+
 Check the build status here: https://dev.azure.com/colyseus/colyseus-unity3d/_build
+
 Check the deploy status here: https://dev.azure.com/colyseus/colyseus-unity3d/_release?_a=releases&view=mine&definitionId=1
+
 Change the release notes if necessary
 
 3. Publish Release

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ RELEASE_VERSION will be used for multiple things:
 - It will add this string as a suffix to attachments of the release (example: plugins-0.11.0.zip
 
 2. Check Github releases for new draft (can take a while)
-Change the releasenotes if necessary
+
+Change the release notes if necessary
 
 3. Publish Release

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ RELEASE_VERSION will be used for multiple things:
 2. Check Github releases for new draft (can take a while)
 
 Check the build status here: https://dev.azure.com/colyseus/colyseus-unity3d/_build
-
 Check the deploy status here: https://dev.azure.com/colyseus/colyseus-unity3d/_release?_a=releases&view=mine&definitionId=1
-
 Change the release notes if necessary
 
 3. Publish Release

--- a/README.md
+++ b/README.md
@@ -21,8 +21,25 @@
   </h3>
 </div>
 
+Master Branch Build Status
 [![Build Status](https://dev.azure.com/colyseus/colyseus-unity3d/_apis/build/status/colyseus-unity3d-CI?branchName=master)](https://dev.azure.com/colyseus/colyseus-unity3d/_build/latest?definitionId=1&branchName=master)
 
 ## License
 
 MIT
+
+### Release
+How to create a release:
+1. Create release branch (release/REALESE_VERSION)
+
+Example branch name: `release/0.11.0`
+
+RELEASE_VERSION will be used for multiple things:
+- It will tag the commit with this string
+- It will name the release with this string
+- It will add this string as a suffix to attachments of the release (example: plugins-0.11.0.zip
+
+2. Check Github releases for new draft (can take a while)
+Change the releasenotes if necessary
+
+3. Publish Release

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ RELEASE_VERSION will be used for multiple things:
 
 Check the build status here: https://dev.azure.com/colyseus/colyseus-unity3d/_build
 
-Check the deploy status here: https://dev.azure.com/colyseus/colyseus-unity3d/_release?_a=releases&view=mine&definitionId=1
+Check the deploy status here: https://dev.azure.com/colyseus/colyseus-unity3d/_release
 
 Change the release notes if necessary
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ RELEASE_VERSION will be used for multiple things:
 - It will add this string as a suffix to attachments of the release (example: plugins-0.11.0.zip
 
 2. Check Github releases for new draft (can take a while)
-
+Check the build status here: https://dev.azure.com/colyseus/colyseus-unity3d/_build
+Check the deploy status here: https://dev.azure.com/colyseus/colyseus-unity3d/_release?_a=releases&view=mine&definitionId=1
 Change the release notes if necessary
 
 3. Publish Release

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 </div>
 
 Master Branch Build Status
+
 [![Build Status](https://dev.azure.com/colyseus/colyseus-unity3d/_apis/build/status/colyseus-unity3d-CI?branchName=master)](https://dev.azure.com/colyseus/colyseus-unity3d/_build/latest?definitionId=1&branchName=master)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   </h3>
 </div>
 
+[![Build Status](https://dev.azure.com/colyseus/colyseus-unity3d/_apis/build/status/colyseus-unity3d-CI?branchName=master)](https://dev.azure.com/colyseus/colyseus-unity3d/_build/latest?definitionId=1&branchName=master)
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ RELEASE_VERSION will be used for multiple things:
 2. Check Github releases for new draft (can take a while)
 
 Check the build status here: https://dev.azure.com/colyseus/colyseus-unity3d/_build
+
 Check the deploy status here: https://dev.azure.com/colyseus/colyseus-unity3d/_release?_a=releases&view=mine&definitionId=1
+
 Change the release notes if necessary
 
 3. Publish Release


### PR DESCRIPTION
First part for https://github.com/colyseus/colyseus-unity3d/issues/92

It describes how to release the repo with CI/CD
The CI/CD which was created takes the assets/plugins folder and adds it as a single zip attachment

suggestion: squash merge so history is not so full with update readme