### PR TITLE
Add missing WebSocket parameter to constructor

### DIFF
--- a/Assets/Plugins/WebSocket/WebSocket.cs
+++ b/Assets/Plugins/WebSocket/WebSocket.cs
@@ -137,7 +137,7 @@ namespace NativeWebSocket {
     public event WebSocketErrorEventHandler OnError;
     public event WebSocketCloseEventHandler OnClose;
 
-    public WebSocket (string url) {
+    public WebSocket (string url, Dictionary<string, string> headers = null) {
       if (!WebSocketFactory.isInitialized) {
         WebSocketFactory.Initialize ();
       }


### PR DESCRIPTION
The lack of the second parameter in the constructor for WebSocket on WebGL would cause the build pipeline to fail. This looks related to the recent addition to enable custom headers. This PR doesn't fully-implement the same functionality on WebGL builds, but does fix the build. 