### PR TITLE
[Fix] Message type size over 32 characters wrong encoding

### DIFF
--- a/Assets/Plugins/Colyseus/Room.cs
+++ b/Assets/Plugins/Colyseus/Room.cs
@@ -155,7 +155,7 @@ namespace Colyseus
 		public async Task Send(string type)
 		{
 			byte[] encodedType = System.Text.Encoding.UTF8.GetBytes(type);
-			byte[] initialBytes = { Protocol.ROOM_DATA, (byte)(encodedType.Length | 0xa0) };
+			byte[] initialBytes = ArrayUtils.getInitialBytesFromEncodedType(encodedType);
 
 			byte[] bytes = new byte[initialBytes.Length + encodedType.Length];
 			Buffer.BlockCopy(initialBytes, 0, bytes, 0, initialBytes.Length);
@@ -175,7 +175,7 @@ namespace Colyseus
 			MsgPack.Serialize(message, serializationOutput, SerializationOptions.SuppressTypeInformation);
 
 			byte[] encodedType = System.Text.Encoding.UTF8.GetBytes(type);
-			byte[] initialBytes = { Protocol.ROOM_DATA, (byte) (encodedType.Length | 0xa0) };
+			byte[] initialBytes = ArrayUtils.getInitialBytesFromEncodedType(encodedType);
 			byte[] encodedMessage = serializationOutput.ToArray();
 
 			byte[] bytes = new byte[encodedType.Length + encodedMessage.Length + initialBytes.Length];

--- a/Assets/Plugins/Colyseus/Utils/ArrayUtils.cs
+++ b/Assets/Plugins/Colyseus/Utils/ArrayUtils.cs
@@ -8,5 +8,68 @@ namespace Colyseus
 		{
 			return new List<byte>(bytes).GetRange(index, length).ToArray();
 		}
+		
+		public static byte[] getInitialBytesFromEncodedType(byte[] encodedType)
+        {
+            byte[] initialBytes = { Protocol.ROOM_DATA };
+
+            if (encodedType.Length < 0x20)
+            {
+                initialBytes = addByteToArray(initialBytes, new byte[] { (byte)(encodedType.Length | 0xa0) });
+            }
+            else if (encodedType.Length < 0x100)
+            {
+                initialBytes = addByteToArray(initialBytes, new byte[] { 0xd9 });
+                initialBytes = uint8(initialBytes, encodedType.Length);
+            }
+            else if (encodedType.Length < 0x10000)
+            {
+                initialBytes = addByteToArray(initialBytes, new byte[] { 0xda });
+                initialBytes = uint16(initialBytes, encodedType.Length);
+            }
+            else if (encodedType.Length < 0x7fffffff)
+            {
+                initialBytes = addByteToArray(initialBytes, new byte[] { 0xdb });
+                initialBytes = uint32(initialBytes, encodedType.Length);
+            }
+            else
+            {
+                throw new System.Exception("String too long");
+            }
+
+            return initialBytes;
+        }
+
+        private static byte[] addByteToArray(byte[] byteArray, byte[] newBytes)
+        {
+            byte[] bytes = new byte[byteArray.Length + newBytes.Length];
+            System.Buffer.BlockCopy(byteArray, 0, bytes, 0, byteArray.Length);
+            System.Buffer.BlockCopy(newBytes, 0, bytes, byteArray.Length, newBytes.Length);
+            return bytes;
+        }
+
+        private static byte[] uint8(byte[] bytes, int value)
+        {
+            return addByteToArray(bytes, new byte[] { (byte)(value & 255) });
+        }
+
+        private static byte[] uint16(byte[] bytes, int value)
+        {
+            var a1 = addByteToArray(bytes, new byte[] { (byte)(value & 255) });
+            return addByteToArray(a1, new byte[] { (byte)((value >> 8) & 255) });
+        }
+
+        private static byte[] uint32(byte[] bytes, int value)
+        {
+            var b4 = value >> 24;
+            var b3 = value >> 16;
+            var b2 = value >> 8;
+            var b1 = value;
+            var a1 = addByteToArray(bytes, new byte[] { (byte)(b1 & 255) });
+            var a2 = addByteToArray(a1, new byte[] { (byte)(b2 & 255) });
+            var a3 = addByteToArray(a2, new byte[] { (byte)(b3 & 255) });
+            return addByteToArray(a3, new byte[] { (byte)(b4 & 255) });
+        }
+    }
 	}
 }


### PR DESCRIPTION
Now it is possible to send message type strings over 32+ characters :)