### PR TITLE
updates deprecated isNetworkError, isHttpError

### DIFF
--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -232,7 +232,7 @@ namespace Colyseus
 			req.downloadHandler = new DownloadHandlerBuffer();
 			await req.SendWebRequest();
 
-			if (req.isNetworkError || req.isHttpError)
+			if (req.result == UnityWebRequest.Result.ConnectionError || req.result == UnityWebRequest.Result.ProtocolError)
 			{
 				throw new Exception(req.error);
 			}


### PR DESCRIPTION
gets rid of warning messages when using latest Unity 2020.2.x.