### PR TITLE
Deprecated warning on request error checking (Since Unity 2020.2)

### DIFF
--- a/Assets/Plugins/Colyseus/Auth.cs
+++ b/Assets/Plugins/Colyseus/Auth.cs
@@ -284,7 +284,6 @@ namespace Colyseus
 				throw new Exception(req.error);
 			}
 #endif
-
 			var json = req.downloadHandler.text;
 
 			// Workaround for decoding a UserDataCollection

--- a/Assets/Plugins/Colyseus/Auth.cs
+++ b/Assets/Plugins/Colyseus/Auth.cs
@@ -271,10 +271,19 @@ namespace Colyseus
 			req.downloadHandler = new DownloadHandlerBuffer();
 			await req.SendWebRequest();
 
+#if UNITY_2020_2_OR_NEWER
+			if (req.result == UnityWebRequest.Result.ConnectionError ||
+			req.result == UnityWebRequest.Result.ProtocolError ||
+			req.result == UnityWebRequest.Result.DataProcessingError)
+			{
+				throw new Exception(req.error);
+			}
+#else
 			if (req.isNetworkError || req.isHttpError)
 			{
 				throw new Exception(req.error);
 			}
+#endif
 
 			var json = req.downloadHandler.text;
 

--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -245,7 +245,6 @@ namespace Colyseus
 				throw new Exception(req.error);
 			}
 #endif
-
 			var response = JsonUtility.FromJson<MatchMakeResponse>(req.downloadHandler.text);
 			if (!string.IsNullOrEmpty(response.error))
 			{

--- a/Assets/Plugins/Colyseus/Client.cs
+++ b/Assets/Plugins/Colyseus/Client.cs
@@ -232,10 +232,19 @@ namespace Colyseus
 			req.downloadHandler = new DownloadHandlerBuffer();
 			await req.SendWebRequest();
 
+#if UNITY_2020_2_OR_NEWER
+			if (req.result == UnityWebRequest.Result.ConnectionError ||
+			req.result == UnityWebRequest.Result.ProtocolError ||
+			req.result == UnityWebRequest.Result.DataProcessingError)
+			{
+				throw new Exception(req.error);
+			}
+#else
 			if (req.isNetworkError || req.isHttpError)
 			{
 				throw new Exception(req.error);
 			}
+#endif
 
 			var response = JsonUtility.FromJson<MatchMakeResponse>(req.downloadHandler.text);
 			if (!string.IsNullOrEmpty(response.error))


### PR DESCRIPTION
Hello, thank you for your hard work on Colyseus. I updated my Unity version and got some deprecated warnings from Auth.cs and Client.cs.
Here is a pull request which should suppress the warnings for Unity 2020.2 and above.

PS : It should be compatible with older version since I used the define 
#if UNITY_2020_2_OR_NEWER