### PR TITLE
Updated Example comment, OverrideSettings bug fix

### DIFF
--- a/Assets/Colyseus/Runtime/Example~/Scripts/ExampleManager.cs
+++ b/Assets/Colyseus/Runtime/Example~/Scripts/ExampleManager.cs
@@ -110,10 +110,10 @@ public class ExampleManager : ColyseusManager<ExampleManager>
             _roomController.Entities, _roomController.EntityViews);
     }
 
-	/// <summary>
-	/// /// Create a new <see cref="ColyseusClient"/> along with any other client initialization you may need to perform
-	/// /// </summary>
-	public override void InitializeClient()
+    /// <summary>
+    /// /// Create a new <see cref="ColyseusClient"/> along with any other client initialization you may need to perform
+    /// /// </summary>
+    public override void InitializeClient()
     {
         base.InitializeClient();
 
@@ -149,14 +149,14 @@ public class ExampleManager : ColyseusManager<ExampleManager>
 
     public void CreateNewRoom(string roomID, Dictionary<string, object> roomOptions)
     {
-	    _roomController.SetRoomOptions(roomOptions);
+        _roomController.SetRoomOptions(roomOptions);
 
-	    CreateNewRoom(roomID);
+        CreateNewRoom(roomID);
     }
 
-	public async void JoinOrCreateRoom()
+    public async void JoinOrCreateRoom()
     {
-	    await _roomController.JoinOrCreateRoom();
+        await _roomController.JoinOrCreateRoom();
     }
 
     public async void LeaveAllRooms(Action onLeave)

--- a/Assets/Colyseus/Runtime/Example~/Scripts/ExampleManager.cs
+++ b/Assets/Colyseus/Runtime/Example~/Scripts/ExampleManager.cs
@@ -110,10 +110,10 @@ public class ExampleManager : ColyseusManager<ExampleManager>
             _roomController.Entities, _roomController.EntityViews);
     }
 
-    /// <summary>
-    ///     Connect to the Colyseus server and either join or create a room.
-    /// </summary>
-    public override void InitializeClient()
+	/// <summary>
+	/// /// Create a new <see cref="ColyseusClient"/> along with any other client initialization you may need to perform
+	/// /// </summary>
+	public override void InitializeClient()
     {
         base.InitializeClient();
 
@@ -147,7 +147,14 @@ public class ExampleManager : ColyseusManager<ExampleManager>
         await _roomController.CreateSpecificRoom(client, _roomController.roomName, roomID);
     }
 
-    public async void JoinOrCreateRoom()
+    public void CreateNewRoom(string roomID, Dictionary<string, object> roomOptions)
+    {
+	    _roomController.SetRoomOptions(roomOptions);
+
+	    CreateNewRoom(roomID);
+    }
+
+	public async void JoinOrCreateRoom()
     {
 	    await _roomController.JoinOrCreateRoom();
     }

--- a/Assets/Colyseus/Runtime/Scripts/Managers/ColyseusManager.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Managers/ColyseusManager.cs
@@ -116,7 +116,7 @@ namespace Colyseus
         public virtual void OverrideSettings(ColyseusSettings newSettings)
         {
             _colyseusSettings = newSettings;
-			_requests = new ColyseusRequest(_colyseusSettings);
+            _requests = new ColyseusRequest(_colyseusSettings);
         }
 
         /// <summary>

--- a/Assets/Colyseus/Runtime/Scripts/Managers/ColyseusManager.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Managers/ColyseusManager.cs
@@ -116,6 +116,7 @@ namespace Colyseus
         public virtual void OverrideSettings(ColyseusSettings newSettings)
         {
             _colyseusSettings = newSettings;
+			_requests = new ColyseusRequest(_colyseusSettings);
         }
 
         /// <summary>


### PR DESCRIPTION
Example code had old comment for ConnectToServer in place for InitializeClient calls. OverrideSettings also was sporadically failing to have the ColyseusRequest use the correct, new settings.  Added Example function to CreateNewRoom with roomOptions dictionary