### PR TITLE
Enhancement/Bug 157 Adjustment

### DIFF
--- a/Assets/Colyseus/Runtime/Example~/Scripts/ExampleRoomController.cs
+++ b/Assets/Colyseus/Runtime/Example~/Scripts/ExampleRoomController.cs
@@ -411,7 +411,7 @@ public class ExampleRoomController
 
     private void OnLeaveRoom(int code)
     {
-	    WebSocketCloseCode parsedCode = WebSocketHelpers.ParseCloseCodeEnum(code);
+        WebSocketCloseCode parsedCode = WebSocketHelpers.ParseCloseCodeEnum(code);
         LSLog.Log(string.Format("ROOM: ON LEAVE =- Reason: {0} ({1})", parsedCode, code));
         _pingThread.Abort();
         _pingThread = null;

--- a/Assets/Colyseus/Runtime/Example~/Scripts/ExampleRoomController.cs
+++ b/Assets/Colyseus/Runtime/Example~/Scripts/ExampleRoomController.cs
@@ -409,14 +409,15 @@ public class ExampleRoomController
         _room.colyseusConnection.OnClose += Room_OnClose;
     }
 
-    private void OnLeaveRoom(WebSocketCloseCode code)
+    private void OnLeaveRoom(int code)
     {
-        LSLog.Log("ROOM: ON LEAVE =- Reason: " + code);
+	    WebSocketCloseCode parsedCode = WebSocketHelpers.ParseCloseCodeEnum(code);
+        LSLog.Log(string.Format("ROOM: ON LEAVE =- Reason: {0} ({1})", parsedCode, code));
         _pingThread.Abort();
         _pingThread = null;
         _room = null;
 
-        if (code != WebSocketCloseCode.Normal && !string.IsNullOrEmpty(_lastRoomId))
+        if (parsedCode != WebSocketCloseCode.Normal && !string.IsNullOrEmpty(_lastRoomId))
         {
             JoinRoomId(_lastRoomId);
         }
@@ -592,7 +593,7 @@ public class ExampleRoomController
     ///     Callback for when the room's connection closes.
     /// </summary>
     /// <param name="closeCode">Code reason for the connection close.</param>
-    private static void Room_OnClose(WebSocketCloseCode closeCode)
+    private static void Room_OnClose(int closeCode)
     {
         LSLog.LogError("Room_OnClose: " + closeCode);
     }

--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusConnection.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusConnection.cs
@@ -1,8 +1,8 @@
+using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NativeWebSocket;
-
 // ReSharper disable InconsistentNaming
 
 namespace Colyseus

--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusConnection.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusConnection.cs
@@ -74,10 +74,11 @@ namespace Colyseus
         ///     <see cref="ProcessingMessageQueue" /> while loop
         /// </remarks>
         /// <param name="code">The cause of the socket closure</param>
-        protected void _OnClose(WebSocketCloseCode code)
+        protected void _OnClose(int code)
         {
             ProcessingMessageQueue = false;
             IsOpen = false;
+			Debug.Log(string.Format("Websocket closed! Code:{0}", code.ToString()));
         }
     }
 }

--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusConnection.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusConnection.cs
@@ -78,7 +78,7 @@ namespace Colyseus
         {
             ProcessingMessageQueue = false;
             IsOpen = false;
-			Debug.Log(string.Format("Websocket closed! Code:{0}", code.ToString()));
+            Debug.Log(string.Format("Websocket closed! Code:{0}", code.ToString()));
         }
     }
 }

--- a/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
@@ -25,7 +25,7 @@ namespace Colyseus
     ///     Delegate function for when <see cref="ColyseusClient" /> leaves this room.
     /// </summary>
     /// <param name="code">Reason for closure</param>
-    public delegate void ColyseusCloseEventHandler(WebSocketCloseCode code);
+    public delegate void ColyseusCloseEventHandler(int code);
 
     /// <summary>
     ///     Delegate function for when some error has been triggered in the room.
@@ -166,7 +166,7 @@ namespace Colyseus
             }
             else
             {
-                OnLeave?.Invoke(WebSocketCloseCode.Normal);
+                OnLeave?.Invoke((int)WebSocketCloseCode.Normal);
             }
         }
 

--- a/Assets/Colyseus/Runtime/WebSocket/WebSocket.cs
+++ b/Assets/Colyseus/Runtime/WebSocket/WebSocket.cs
@@ -84,7 +84,7 @@ namespace NativeWebSocket
     public delegate void WebSocketOpenEventHandler();
     public delegate void WebSocketMessageEventHandler(byte[] data);
     public delegate void WebSocketErrorEventHandler(string errorMsg);
-    public delegate void WebSocketCloseEventHandler(WebSocketCloseCode closeCode);
+    public delegate void WebSocketCloseEventHandler(int closeCode);
 
     public enum WebSocketCloseCode
     {
@@ -328,7 +328,7 @@ namespace NativeWebSocket
     }
 
     public void DelegateOnCloseEvent (int closeCode) {
-      this.OnClose?.Invoke (WebSocketHelpers.ParseCloseCodeEnum (closeCode));
+      this.OnClose?.Invoke (closeCode);
     }
 
   }
@@ -400,7 +400,7 @@ namespace NativeWebSocket
             catch (Exception ex)
             {
                 OnError?.Invoke(ex.Message);
-                OnClose?.Invoke(WebSocketCloseCode.Abnormal);
+                OnClose?.Invoke((int)WebSocketCloseCode.Abnormal);
             }
             finally
             {
@@ -559,7 +559,7 @@ namespace NativeWebSocket
 
         public async Task Receive()
         {
-            WebSocketCloseCode closeCode = WebSocketCloseCode.Abnormal;
+            int closeCode = (int)WebSocketCloseCode.Abnormal;
             await new WaitForBackgroundThread();
 
             ArraySegment<byte> buffer = new ArraySegment<byte>(new byte[8192]);
@@ -601,7 +601,7 @@ namespace NativeWebSocket
                         else if (result.MessageType == WebSocketMessageType.Close)
                         {
                             await Close();
-                            closeCode = WebSocketHelpers.ParseCloseCodeEnum((int)result.CloseStatus);
+                            closeCode = (int)result.CloseStatus;
                             break;
                         }
                     }

--- a/Assets/Colyseus/Runtime/WebSocket/WebSocket.cs
+++ b/Assets/Colyseus/Runtime/WebSocket/WebSocket.cs
@@ -316,19 +316,19 @@ namespace NativeWebSocket
     }
 
     public void DelegateOnOpenEvent () {
-      this.OnOpen?.Invoke ();
+        this.OnOpen?.Invoke ();
     }
 
     public void DelegateOnMessageEvent (byte[] data) {
-      this.OnMessage?.Invoke (data);
+        this.OnMessage?.Invoke (data);
     }
 
     public void DelegateOnErrorEvent (string errorMsg) {
-      this.OnError?.Invoke (errorMsg);
+        this.OnError?.Invoke (errorMsg);
     }
 
     public void DelegateOnCloseEvent (int closeCode) {
-      this.OnClose?.Invoke (closeCode);
+        this.OnClose?.Invoke (closeCode);
     }
 
   }


### PR DESCRIPTION
Socket closure events now pass around the int code instead of the parsed enum value. This will cause errors anywhere that you have created custom `_room.colyseusConnection.OnClose` / `_room.colyseusConnection.OnLeave` events that are anticipating a `WebSocketCloseCode` argument rather than an int. The `WebSocketCloseCode` can still be obtained via `WebSocketHelpers.ParseCloseCodeEnum(code)`