### PR TITLE
ScriptableObject should be instantiated using ScriptableObject.Create…

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusClient.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusClient.cs
@@ -74,12 +74,10 @@ namespace Colyseus
             Endpoint = new UriBuilder(new Uri(endpoint));
 
             // Create ColyseusSettings object to pass to the ColyseusRequest object
-            ColyseusSettings settings = new ColyseusSettings()
-	            {
-		            colyseusServerAddress = Endpoint.Host,
-		            colyseusServerPort = Endpoint.Port.ToString(),
-					useSecureProtocol = Endpoint.ToString().StartsWith("wss") || Endpoint.ToString().StartsWith("https")
-	            };
+            ColyseusSettings settings = ScriptableObject.CreateInstance<ColyseusSettings>();
+            settings.colyseusServerAddress = Endpoint.Host;
+            settings.colyseusServerPort = Endpoint.Port.ToString();
+            settings.useSecureProtocol = Endpoint.ToString().StartsWith("wss") || Endpoint.ToString().StartsWith("https");
 
             Settings = settings;
 		}


### PR DESCRIPTION
ScriptableObjects should be instantiated using ScripableObject.CreateInstance. Unity was throwing a warning, this fixes it.