### PR TITLE
Fixing usage of deprecated UnityWebRequest methods

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
+++ b/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
@@ -53,7 +53,7 @@ namespace Colyseus
             req.downloadHandler = new DownloadHandlerBuffer();
             await req.SendWebRequest();
 
-            if (req.isNetworkError || req.isHttpError)
+            if (req.result== UnityWebRequest.Result.ConnectionError || req.result== UnityWebRequest.Result.ProtocolError)
             {
                 if (_serverSettings.useSecureProtocol)
                 {
@@ -110,7 +110,7 @@ namespace Colyseus
             req.downloadHandler = new DownloadHandlerBuffer();
             await req.SendWebRequest();
 
-            if (req.isNetworkError || req.isHttpError)
+            if (req.result== UnityWebRequest.Result.ConnectionError || req.result== UnityWebRequest.Result.ProtocolError)
             {
                 if (_serverSettings.useSecureProtocol)
                 {


### PR DESCRIPTION
ColyseusRequest.cs file uses two deprecated UnityWebRequest methods which are:

 "UnityWebRequest.isHttpError" and "UnityWebRequest.isNetworkError" 

  - UnityWebRequest.isHttpError must be changed with new UnityWebRequest.Result.ConnectionError method
  - UnityWebRequest.isNetworkError must be changed with new UnityWebRequest.Result.ProtocolError method
