### PR TITLE
Fixing usage of deprecated UnityWebRequest methods

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
+++ b/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
@@ -53,7 +53,11 @@ namespace Colyseus
             req.downloadHandler = new DownloadHandlerBuffer();
             await req.SendWebRequest();
 
-            if (req.result== UnityWebRequest.Result.ConnectionError || req.result== UnityWebRequest.Result.ProtocolError)
+#if UNITY_2020_1_OR_NEWER
+            if (req.result == UnityWebRequest.Result.ConnectionError || req.result == UnityWebRequest.Result.ProtocolError)
+#else
+            if (req.isNetworkError || req.isHttpError)
+#endif
             {
                 if (_serverSettings.useSecureProtocol)
                 {
@@ -110,7 +114,11 @@ namespace Colyseus
             req.downloadHandler = new DownloadHandlerBuffer();
             await req.SendWebRequest();
 
-            if (req.result== UnityWebRequest.Result.ConnectionError || req.result== UnityWebRequest.Result.ProtocolError)
+#if UNITY_2020_1_OR_NEWER
+            if (req.result == UnityWebRequest.Result.ConnectionError || req.result == UnityWebRequest.Result.ProtocolError)
+#else
+            if (req.isNetworkError || req.isHttpError)
+#endif
             {
                 if (_serverSettings.useSecureProtocol)
                 {


### PR DESCRIPTION
Brought in changes from PR 167 but added the preprocessing commands to support lower versions than Unity 2020