### PR TITLE
prevent properties from being stripped out of WebGL builds.

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/Serializer/Schema/Types/ColyseusReflection.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Serializer/Schema/Types/ColyseusReflection.cs
@@ -21,7 +21,7 @@ namespace Colyseus.Schema
         public string type;
 
         [Type(2, "number")]
-        public float referencedType;
+        public float referencedType = -1;
     }
 
     /// <summary>
@@ -56,6 +56,6 @@ namespace Colyseus.Schema
         public ArraySchema<ReflectionType> types = new ArraySchema<ReflectionType>();
 
         [Type(1, "number")]
-        public float rootType;
+        public float rootType = -1;
     }
 }


### PR DESCRIPTION
This issue has been reported recently. Happening only on WebGL builds. 

```
OverflowException: Value was either too large or too small for an Int32.
  at System.Convert.ToInt32 (System.Double value) [0x00000] in <00000000000000000000000000000000>:0 
```

After inspecting, it has been found out that the error happened during schema serializer's `Handshake`, where `fieldsByIndex` did not contain one of the fields defined via `[Type()]` annotation: 

https://github.com/colyseus/colyseus-unity3d/blob/f80f7f402ad2e51c4ebad59db389c0b4d05ee1ad/Assets/Colyseus/Runtime/Scripts/Serializer/Schema/Schema.cs#L430

This PR fixes the issue.