### PR TITLE
Added try catch for schema mismatch exception

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
@@ -372,7 +372,13 @@ namespace Colyseus
 
                 if (bytes.Length > offset)
                 {
-                    serializer.Handshake(bytes, offset);
+	                try {
+		                serializer.Handshake(bytes, offset);
+	                }
+	                catch (Exception e)
+	                {
+		                OnError?.Invoke(0, e.Message);
+	                }
                 }
 
                 OnJoin?.Invoke();


### PR DESCRIPTION
In case of schema mismatch the ConsumeSeatReservation Task was stuck forever. This is because the OnError callback which would complete the task was never called. This commit adds the invoke of OnError.