### PR TITLE
Fix schema mismatch exception

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusErrorCode.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusErrorCode.cs
@@ -1,0 +1,24 @@
+// ReSharper disable InconsistentNaming
+
+namespace Colyseus
+{
+    /// <summary>
+    ///     Colyseus error codes mapping.
+    /// </summary>
+    public class ColyseusErrorCode
+    {
+	    public static int MATCHMAKE_NO_HANDLER = 4210;
+	    public static int MATCHMAKE_INVALID_CRITERIA = 4211;
+	    public static int MATCHMAKE_INVALID_ROOM_ID = 4212;
+	    public static int MATCHMAKE_UNHANDLED = 4213;
+	    public static int MATCHMAKE_EXPIRED = 4214;
+
+	    public static int AUTH_FAILED = 4215;
+	    public static int APPLICATION_ERROR = 4216;
+
+	    /// <summary>
+	    ///     When local schema is different from schema on the server.
+	    /// </summary>
+	    public static int SCHEMA_MISMATCH = 4217;
+    }
+}

--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusErrorCode.cs.meta
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusErrorCode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae77dae9e2a2d3d4d82f6d3cc8ef2f12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
@@ -377,7 +377,9 @@ namespace Colyseus
 	                }
 	                catch (Exception e)
 	                {
+		                await Leave(false);
 		                OnError?.Invoke(0, e.Message);
+		                return;
 	                }
                 }
 

--- a/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
@@ -378,7 +378,7 @@ namespace Colyseus
 	                catch (Exception e)
 	                {
 		                await Leave(false);
-		                OnError?.Invoke(0, e.Message);
+		                OnError?.Invoke(ColyseusErrorCode.SCHEMA_MISMATCH, e.Message);
 		                return;
 	                }
                 }

--- a/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Room/ColyseusRoom.cs
@@ -372,7 +372,13 @@ namespace Colyseus
 
                 if (bytes.Length > offset)
                 {
-                    serializer.Handshake(bytes, offset);
+	                try {
+		                serializer.Handshake(bytes, offset);
+	                }
+	                catch (Exception e)
+	                {
+		                OnError?.Invoke(0, e.Message);
+	                }
                 }
 
                 OnJoin?.Invoke();


### PR DESCRIPTION
In case of schema mismatch the ConsumeSeatReservation Task was stuck forever. This is because the OnError callback which would complete the task was never called. Also the player is still in the room but unable to do anything.

Those commits are a simple fix, now the schema mismatch exception will be thrown and player will automatically leave the room.