### PR TITLE
Allow use of path appended to server address

### DIFF
--- a/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
+++ b/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
@@ -29,6 +29,7 @@ namespace Colyseus
             {
                 req.method = uriMethod;
                 req.url = GetWebRequestURL(uriPath, uriQuery);
+
 				// Send JSON on request body
 				if (data != null)
                 {
@@ -132,22 +133,28 @@ namespace Colyseus
             };
         }
 
+        public UriBuilder GetUriBuilder(string path, string query = "")
+		{
+            string forwardSlash = "";
+
+            if (!_serverSettings.WebRequestEndpoint.EndsWith("/"))
+            {
+                forwardSlash = "/";
+            }
+
+            // WebRequestEndpoint will include any path that is included with the server address field of the server settings object so we need to add the request specific path to the WebRequestEndpoint value
+            UriBuilder uriBuilder = new UriBuilder($"{_serverSettings.WebRequestEndpoint}{forwardSlash}{path}");
+
+            uriBuilder.Port = _serverSettings.DetermineServerPort();
+            uriBuilder.Query = query;
+
+            return uriBuilder;
+        }
+
         private string GetWebRequestURL(string path, string query = "")
         {
-	        string forwardSlash = "";
 
-	        if (!_serverSettings.WebRequestEndpoint.EndsWith("/"))
-	        {
-		        forwardSlash = "/";
-	        }
-
-	        // WebRequestEndpoint will include any path that is included with the server address field of the server settings object so we need to add the request specific path to the WebRequestEndpoint value
-	        UriBuilder uriBuilder = new UriBuilder($"{_serverSettings.WebRequestEndpoint}{forwardSlash}{path}");
-
-	        uriBuilder.Port = _serverSettings.DetermineServerPort();
-	        uriBuilder.Query = query;
-
-	        return uriBuilder.ToString();
+            return GetUriBuilder(path, query).ToString();
         }
 	}
 }

--- a/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
+++ b/Assets/Colyseus/Runtime/Scripts/ColyseusRequest.cs
@@ -25,17 +25,12 @@ namespace Colyseus
 
         public async Task<string> Request(string uriMethod, string uriPath, string uriQuery, string Token = "", UploadHandlerRaw data = null)
         {
-            UriBuilder uriBuilder = new UriBuilder(_serverSettings.WebRequestEndpoint);
-            uriBuilder.Path = uriPath;
-            uriBuilder.Query = uriQuery;
-
             using (UnityWebRequest req = new UnityWebRequest())
             {
                 req.method = uriMethod;
-        
-                req.url = uriBuilder.Uri.ToString();
-                // Send JSON on request body
-                if (data != null)
+                req.url = GetWebRequestURL(uriPath, uriQuery);
+				// Send JSON on request body
+				if (data != null)
                 {
                     req.uploadHandler = data;
                 }
@@ -81,13 +76,10 @@ namespace Colyseus
 
         public async Task<string> Request(string uriMethod, string uriPath, Dictionary<string, object> options = null, Dictionary<string, string> headers = null)
         {
-            UriBuilder uriBuilder = new UriBuilder(_serverSettings.WebRequestEndpoint);
-            uriBuilder.Path = uriPath;
-
-            using (UnityWebRequest req = new UnityWebRequest())
+			using (UnityWebRequest req = new UnityWebRequest())
             {
                 req.method = uriMethod;
-                req.url = uriBuilder.Uri.ToString();
+                req.url = GetWebRequestURL(uriPath);
                 LSLog.Log($"Requesting from URL: {req.url}");
                 if (options != null)
                 {
@@ -139,5 +131,23 @@ namespace Colyseus
                 return req.downloadHandler.text;
             };
         }
-    }
+
+        private string GetWebRequestURL(string path, string query = "")
+        {
+	        string forwardSlash = "";
+
+	        if (!_serverSettings.WebRequestEndpoint.EndsWith("/"))
+	        {
+		        forwardSlash = "/";
+	        }
+
+	        // WebRequestEndpoint will include any path that is included with the server address field of the server settings object so we need to add the request specific path to the WebRequestEndpoint value
+	        UriBuilder uriBuilder = new UriBuilder($"{_serverSettings.WebRequestEndpoint}{forwardSlash}{path}");
+
+	        uriBuilder.Port = _serverSettings.DetermineServerPort();
+	        uriBuilder.Query = query;
+
+	        return uriBuilder.ToString();
+        }
+	}
 }

--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusClient.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusClient.cs
@@ -389,11 +389,8 @@ namespace Colyseus
                 list.Add(item.Key + "=" + (item.Value != null ? Convert.ToString(item.Value) : "null"));
             }
 
-            UriBuilder uriBuilder = new UriBuilder(Endpoint.Uri)
-            {
-                Path = path,
-                Query = string.Join("&", list.ToArray())
-            };
+            var uriBuilder = colyseusRequest.GetUriBuilder(path, string.Join("&", list.ToArray()));
+            uriBuilder.Scheme = Endpoint.Scheme;
 
             return new ColyseusConnection(uriBuilder.ToString(), headers);
         }

--- a/Assets/Colyseus/Runtime/Scripts/Models/ColyseusClient.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Models/ColyseusClient.cs
@@ -62,24 +62,24 @@ namespace Colyseus
 		/// </summary>
         public ColyseusRequest colyseusRequest;
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ColyseusClient" /> class with
-        ///     the specified Colyseus Game Server endpoint.
-        /// </summary>
-        /// <param name="endpoint">
-        ///     A <see cref="string" /> that represents the WebSocket URL to connect.
-        /// </param>
-        public ColyseusClient(string endpoint)
-        {
-            Endpoint = new UriBuilder(new Uri(endpoint));
+		/// <summary>
+		///     Initializes a new instance of the <see cref="ColyseusClient" /> class with
+		///     the specified Colyseus Game Server endpoint.
+		/// </summary>
+		/// <param name="endpoint">
+		///     A <see cref="string" /> that represents the WebSocket URL to connect.
+		/// </param>
+		public ColyseusClient(string endpoint)
+		{
+			Endpoint = new UriBuilder(endpoint);
 
-            // Create ColyseusSettings object to pass to the ColyseusRequest object
-            ColyseusSettings settings = ScriptableObject.CreateInstance<ColyseusSettings>();
-            settings.colyseusServerAddress = Endpoint.Host;
-            settings.colyseusServerPort = Endpoint.Port.ToString();
-            settings.useSecureProtocol = Endpoint.ToString().StartsWith("wss") || Endpoint.ToString().StartsWith("https");
+			// Create ColyseusSettings object to pass to the ColyseusRequest object
+			ColyseusSettings settings = ScriptableObject.CreateInstance<ColyseusSettings>();
+			settings.colyseusServerAddress = $"{Endpoint.Host}{Endpoint.Path}";
+			settings.colyseusServerPort = Endpoint.Port.ToString();
+			settings.useSecureProtocol = string.Equals(Endpoint.Scheme, "wss") || string.Equals(Endpoint.Scheme, "https");
 
-            Settings = settings;
+			Settings = settings;
 		}
 
 		/// <summary>
@@ -95,7 +95,7 @@ namespace Colyseus
 
 		public void SetSettings(ColyseusSettings settings, bool useWebSocketEndpoint)
 		{
-			Endpoint = new UriBuilder(new Uri(useWebSocketEndpoint ? settings.WebSocketEndpoint : settings.WebRequestEndpoint));
+			Endpoint = new UriBuilder(useWebSocketEndpoint ? settings.WebSocketEndpoint : settings.WebRequestEndpoint);
 
 			Settings = settings;
 		}

--- a/Assets/Colyseus/Runtime/Scripts/Settings/ColyseusSettings.cs
+++ b/Assets/Colyseus/Runtime/Scripts/Settings/ColyseusSettings.cs
@@ -83,13 +83,8 @@ namespace Colyseus
         {
             get
             {
-                if (string.IsNullOrEmpty(colyseusServerPort) || colyseusServerPort.Equals(("80")))
-                {
-                    return (useSecureProtocol ? "wss" : "ws") + "://" + colyseusServerAddress;
-                }
-
-                return (useSecureProtocol ? "wss" : "ws") + "://" + colyseusServerAddress + ":" + colyseusServerPort;
-            }
+				return BuildWebSocketEndpoint();
+			}
         }
 
         /// <summary>
@@ -99,13 +94,8 @@ namespace Colyseus
         {
             get
             {
-                if (string.IsNullOrEmpty(colyseusServerPort) || colyseusServerPort.Equals(("80")))
-                {
-                    return (useSecureProtocol ? "https" : "http") + "://" + colyseusServerAddress;
-                }
-
-                return (useSecureProtocol ? "https" : "http") + "://" + colyseusServerAddress + ":" + colyseusServerPort;
-            }
+				return BuildWebRequestEndpoint();
+			}
         }
 
         /// <summary>
@@ -123,5 +113,57 @@ namespace Colyseus
 
             return clone;
         }
-    }
+
+        private string BuildWebRequestEndpoint()
+        {
+	        UriBuilder webRequestEndpointBuilder = new UriBuilder(GetBaseEndpoint(GetWebRequestEndpointScheme()));
+
+	        webRequestEndpointBuilder.Port = DetermineServerPort();
+
+	        return webRequestEndpointBuilder.ToString();
+        }
+
+        private string BuildWebSocketEndpoint()
+        {
+	        UriBuilder webSocketEndpointBuilder = new UriBuilder(GetBaseEndpoint(GetWebSocketEndpointScheme()));
+
+	        webSocketEndpointBuilder.Port = DetermineServerPort();
+
+	        return webSocketEndpointBuilder.ToString();
+        }
+
+        private string GetBaseEndpoint(string scheme)
+        {
+	        return $"{scheme}://{colyseusServerAddress}";
+        }
+
+        private string GetWebSocketEndpointScheme()
+        {
+	        return (useSecureProtocol ? "wss" : "ws");
+        }
+
+        private string GetWebRequestEndpointScheme()
+        {
+	        return (useSecureProtocol ? "https" : "http");
+        }
+
+        public int DetermineServerPort()
+        {
+	        if (ShouldIncludeServerPort() && int.TryParse(colyseusServerPort, out int serverPort))
+	        {
+		        return serverPort;
+	        }
+	        else
+	        {
+		        Debug.LogError($"Get Web Request Endpoint - Error parsing server port: \"{colyseusServerPort}\"");
+
+		        return -1;
+	        }
+        }
+
+        private bool ShouldIncludeServerPort()
+        {
+	        return !string.IsNullOrEmpty(colyseusServerPort) && !string.Equals(colyseusServerPort, "80");
+        }
+	}
 }


### PR DESCRIPTION
Implemented fix to allow the use of an additional path appended to the host of the server address.  The path included in the server address is now included in the websocket and web request endpoints.